### PR TITLE
Support DurationTime in sum() builtin function

### DIFF
--- a/ccc/infrastructure/src/evaluator/builtin.rs
+++ b/ccc/infrastructure/src/evaluator/builtin.rs
@@ -114,12 +114,21 @@ fn list_len(arguments: &[Value]) -> Result<Value, CccError> {
     Ok(Value::Integer(elements.len() as i64))
 }
 
-fn list_sum(arguments: &[Value]) -> Result<Value, CccError> {
-    let elements = expect_single_list("sum", arguments)?;
+fn sum_durations(elements: &[Value]) -> Result<Value, CccError> {
+    let mut total_seconds: i64 = 0;
+    for elem in elements {
+        match elem {
+            Value::DurationTime(s) => total_seconds += s,
+            _ => return Err(CccError::eval("sum: list elements must be the same type")),
+        }
+    }
+    Ok(Value::DurationTime(total_seconds))
+}
+
+fn sum_numbers(elements: &[Value]) -> Result<Value, CccError> {
     let mut has_float = false;
     let mut int_sum: i64 = 0;
     let mut float_sum: f64 = 0.0;
-
     for elem in elements {
         match elem {
             Value::Integer(n) => {
@@ -130,17 +139,24 @@ fn list_sum(arguments: &[Value]) -> Result<Value, CccError> {
                 has_float = true;
                 float_sum += n;
             }
-            Value::List(_) => return Err(CccError::eval("sum: list elements must be numbers")),
-            Value::DurationTime(_) | Value::DateTime { .. } | Value::Timestamp(_) => {
-                return Err(CccError::eval("sum: list elements must be numbers"));
-            }
+            _ => return Err(CccError::eval("sum: list elements must be the same type")),
         }
     }
-
     if has_float {
         Ok(Value::Float(float_sum))
     } else {
         Ok(Value::Integer(int_sum))
+    }
+}
+
+fn list_sum(arguments: &[Value]) -> Result<Value, CccError> {
+    let elements = expect_single_list("sum", arguments)?;
+
+    match elements.first() {
+        None => Ok(Value::Integer(0)),
+        Some(Value::DurationTime(_)) => sum_durations(elements),
+        Some(Value::Integer(_) | Value::Float(_)) => sum_numbers(elements),
+        _ => Err(CccError::eval("sum: unsupported element type")),
     }
 }
 

--- a/ccc/presentation/tests/cli_test.rs
+++ b/ccc/presentation/tests/cli_test.rs
@@ -374,6 +374,42 @@ fn evaluate_sum_empty() {
 }
 
 #[test]
+fn evaluate_sum_duration() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("sum([10:00:00, 8:00:00])").assert();
+
+    // Assert
+    result.success().stdout("18:00:00\n");
+}
+
+#[test]
+fn evaluate_sum_duration_multiple() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("sum([1:00:00, 0:30:00, 0:15:00])").assert();
+
+    // Assert
+    result.success().stdout("1:45:00\n");
+}
+
+#[test]
+fn evaluate_sum_duration_divided() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("sum([10:00:00, 8:00:00])/2").assert();
+
+    // Assert
+    result.success().stdout("9:00:00\n");
+}
+
+#[test]
 fn evaluate_prod() {
     // Arrange
     let mut cmd = ccc();


### PR DESCRIPTION
## Summary

- `sum()` が `DurationTime` のリストに対応していなかった問題を修正
- `sum_durations` / `sum_numbers` にロジックを分離し、`list_sum` のディスパッチをシンプルに保った
- `sum([10:00:00, 8:00:00])` → `18:00:00`、`sum([10:00:00, 8:00:00])/2` → `9:00:00` が動作するようになった

## Test plan

- [x] `sum([10:00:00, 8:00:00])` → `18:00:00`
- [x] `sum([1:00:00, 0:30:00, 0:15:00])` → `1:45:00`
- [x] `sum([10:00:00, 8:00:00])/2` → `9:00:00`
- [x] `sum([])` → `0` (既存テスト維持)
- [x] 全296テスト通過

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)