### PR TITLE
Support MM:SS duration literal format

### DIFF
--- a/ccc/infrastructure/src/parser/grammar.pest
+++ b/ccc/infrastructure/src/parser/grammar.pest
@@ -22,7 +22,10 @@ datetime_literal = @{
 }
 timezone_offset = @{ "Z" | (("+" | "-") ~ ASCII_DIGIT{2} ~ (":" ~ ASCII_DIGIT{2})?) }
 
-duration_literal = @{ ASCII_DIGIT+ ~ ":" ~ ASCII_DIGIT{2} ~ ":" ~ ASCII_DIGIT{2} }
+duration_literal = @{
+    ASCII_DIGIT+ ~ ":" ~ ASCII_DIGIT{2} ~ ":" ~ ASCII_DIGIT{2}
+  | ASCII_DIGIT+ ~ ":" ~ ASCII_DIGIT{2}
+}
 
 number = @{ float | integer }
 float = @{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }

--- a/ccc/infrastructure/src/parser/pest_based_parser.rs
+++ b/ccc/infrastructure/src/parser/pest_based_parser.rs
@@ -266,15 +266,30 @@ impl PestBasedParser {
     fn build_duration_literal(pair: pest::iterators::Pair<Rule>) -> Result<Expression, CccError> {
         let source = pair.as_str();
         let parts: Vec<&str> = source.split(':').collect();
-        let hours = parts[0]
-            .parse::<i64>()
-            .map_err(|e| CccError::parse(format!("invalid duration hours: {e}")))?;
-        let minutes = parts[1]
-            .parse::<u8>()
-            .map_err(|e| CccError::parse(format!("invalid duration minutes: {e}")))?;
-        let seconds = parts[2]
-            .parse::<u8>()
-            .map_err(|e| CccError::parse(format!("invalid duration seconds: {e}")))?;
+
+        let (hours, minutes, seconds) = if parts.len() == 2 {
+            // MM:SS format
+            let minutes = parts[0]
+                .parse::<u8>()
+                .map_err(|e| CccError::parse(format!("invalid duration minutes: {e}")))?;
+            let seconds = parts[1]
+                .parse::<u8>()
+                .map_err(|e| CccError::parse(format!("invalid duration seconds: {e}")))?;
+            (0i64, minutes, seconds)
+        } else {
+            // HH:MM:SS format
+            let hours = parts[0]
+                .parse::<i64>()
+                .map_err(|e| CccError::parse(format!("invalid duration hours: {e}")))?;
+            let minutes = parts[1]
+                .parse::<u8>()
+                .map_err(|e| CccError::parse(format!("invalid duration minutes: {e}")))?;
+            let seconds = parts[2]
+                .parse::<u8>()
+                .map_err(|e| CccError::parse(format!("invalid duration seconds: {e}")))?;
+            (hours, minutes, seconds)
+        };
+
         if minutes >= 60 {
             return Err(CccError::parse(format!(
                 "duration minutes out of range: {minutes} (must be 0-59)"

--- a/ccc/infrastructure/src/parser/pest_based_parser_test.rs
+++ b/ccc/infrastructure/src/parser/pest_based_parser_test.rs
@@ -726,6 +726,56 @@ mod tests {
     }
 
     #[test]
+    fn parse_duration_mm_ss_basic() {
+        // Arrange
+        let input = "10:00";
+
+        // Act
+        let result = parse_expr(input);
+
+        // Assert
+        assert_eq!(
+            result,
+            Expression::DurationTime {
+                hours: 0,
+                minutes: 10,
+                seconds: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_duration_mm_ss_with_seconds() {
+        // Arrange
+        let input = "1:30";
+
+        // Act
+        let result = parse_expr(input);
+
+        // Assert
+        assert_eq!(
+            result,
+            Expression::DurationTime {
+                hours: 0,
+                minutes: 1,
+                seconds: 30,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_duration_mm_ss_seconds_out_of_range_is_error() {
+        // Arrange
+        let parser = PestBasedParser;
+
+        // Act
+        let result = parser.parse("10:60");
+
+        // Assert
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn parse_duration_minutes_out_of_range_is_error() {
         // Arrange
         let parser = PestBasedParser;

--- a/ccc/presentation/tests/cli_test.rs
+++ b/ccc/presentation/tests/cli_test.rs
@@ -769,6 +769,44 @@ fn evaluate_duration_zero() {
     result.success().stdout("0:00:00\n");
 }
 
+// --- MM:SS duration ---
+
+#[test]
+fn evaluate_duration_mm_ss() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("10:00").assert();
+
+    // Assert
+    result.success().stdout("0:10:00\n");
+}
+
+#[test]
+fn evaluate_duration_mm_ss_with_seconds() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("1:30").assert();
+
+    // Assert
+    result.success().stdout("0:01:30\n");
+}
+
+#[test]
+fn evaluate_datetime_add_mm_ss_duration() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("2025-12-25T15:30:00+09 + 10:00").assert();
+
+    // Assert
+    result.success().stdout("2025-12-25T15:40:00+09:00\n");
+}
+
 // --- DateTime ---
 
 #[test]


### PR DESCRIPTION
## Summary

- `grammar.pest` の `duration_literal` ルールに `MM:SS` の2パート形式を追加
- `build_duration_literal` で2パート時に `hours: 0` を補完
- `10:00` → `0:10:00`（10分0秒）として解釈される

## Test plan

- [x] パーサーテスト: `10:00` → DurationTime { hours: 0, minutes: 10, seconds: 0 }
- [x] パーサーテスト: `1:30` → DurationTime { hours: 0, minutes: 1, seconds: 30 }
- [x] パーサーテスト: `10:60` → エラー（秒が範囲外）
- [x] CLI テスト: `10:00` → `0:10:00`
- [x] CLI テスト: `1:30` → `0:01:30`
- [x] CLI テスト: `2025-12-25T15:30:00+09 + 10:00` → `2025-12-25T15:40:00+09:00`
- [x] 既存テスト全319件通過
- [x] 複雑度: 49.38 → 52.29（微増）

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)