### PR TITLE
Support ** as alias for ^ power operator

### DIFF
--- a/ccc/infrastructure/src/parser/grammar.pest
+++ b/ccc/infrastructure/src/parser/grammar.pest
@@ -34,8 +34,8 @@ integer = @{ ASCII_DIGIT+ }
 identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 additive_operator = { "+" | "-" }
-multiplicative_operator = { "*" | "/" | "%" }
-power_operator = { "^" }
+multiplicative_operator = { !"**" ~ "*" | "/" | "%" }
+power_operator = { "**" | "^" }
 unary_operator = { "+" | "-" }
 
 WHITESPACE = _{ " " | "\t" }

--- a/ccc/infrastructure/src/parser/pest_based_parser_test.rs
+++ b/ccc/infrastructure/src/parser/pest_based_parser_test.rs
@@ -234,6 +234,44 @@ mod tests {
     }
 
     #[test]
+    fn parse_double_star_power() {
+        // Arrange
+        let input = "2 ** 3";
+        let expected = Expression::BinaryOperation {
+            operator: BinaryOperation::Power,
+            left: Box::new(Expression::Integer(2)),
+            right: Box::new(Expression::Integer(3)),
+        };
+
+        // Act
+        let result = parse_expr(input);
+
+        // Assert
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_double_star_right_associative() {
+        // Arrange: 2**3**2 = 2**(3**2), NOT (2**3)**2
+        let input = "2 ** 3 ** 2";
+        let expected = Expression::BinaryOperation {
+            operator: BinaryOperation::Power,
+            left: Box::new(Expression::Integer(2)),
+            right: Box::new(Expression::BinaryOperation {
+                operator: BinaryOperation::Power,
+                left: Box::new(Expression::Integer(3)),
+                right: Box::new(Expression::Integer(2)),
+            }),
+        };
+
+        // Act
+        let result = parse_expr(input);
+
+        // Assert
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn parse_power_right_associative() {
         // Arrange: 2^3^2 = 2^(3^2), NOT (2^3)^2
         let input = "2 ^ 3 ^ 2";

--- a/ccc/presentation/tests/cli_test.rs
+++ b/ccc/presentation/tests/cli_test.rs
@@ -205,6 +205,44 @@ fn evaluate_power_right_associative() {
     result.success().stdout("512\n");
 }
 
+// --- ** operator ---
+
+#[test]
+fn evaluate_double_star_power() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("2 ** 3").assert();
+
+    // Assert
+    result.success().stdout("8\n");
+}
+
+#[test]
+fn evaluate_double_star_right_associative() {
+    // Arrange: 2**3**2 = 2**(3**2) = 2**9 = 512
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("2**3**2").assert();
+
+    // Assert
+    result.success().stdout("512\n");
+}
+
+#[test]
+fn evaluate_multiply_vs_double_star_precedence() {
+    // Arrange: 2 * 3 ** 2 = 2 * 9 = 18
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("2 * 3 ** 2").assert();
+
+    // Assert
+    result.success().stdout("18\n");
+}
+
 // --- Error cases ---
 
 #[test]


### PR DESCRIPTION
## Summary

- `grammar.pest` の `power_operator` に `**` を追加
- `multiplicative_operator` に `!"**"` の negative lookahead を追加し、`*` が `**` の最初の文字を消費しないようにした
- `**` は `^` と同じ右結合・同じ優先順位

## Test plan

- [x] パーサーテスト: `2 ** 3` → Power(2, 3)
- [x] パーサーテスト: `2 ** 3 ** 2` → 右結合 Power(2, Power(3, 2))
- [x] CLI テスト: `2 ** 3` → `8`
- [x] CLI テスト: `2**3**2` → `512`（右結合）
- [x] CLI テスト: `2 * 3 ** 2` → `18`（優先順位）
- [x] 既存の `^` テスト全て通過
- [x] 全324テスト通過

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)