### PR TITLE
Restrict list elements to a single homogeneous type

### DIFF
--- a/ccc/domain/src/static_type.rs
+++ b/ccc/domain/src/static_type.rs
@@ -3,7 +3,8 @@
 pub enum StaticType {
     Integer,
     Float,
-    List,
+    /// List with a known element type. `None` represents an empty list.
+    List(Option<Box<StaticType>>),
     DurationTime,
     DateTime,
     Timestamp,
@@ -15,7 +16,8 @@ impl std::fmt::Display for StaticType {
         match self {
             StaticType::Integer => write!(f, "integer"),
             StaticType::Float => write!(f, "float"),
-            StaticType::List => write!(f, "list"),
+            StaticType::List(None) => write!(f, "list"),
+            StaticType::List(Some(elem)) => write!(f, "list[{elem}]"),
             StaticType::DurationTime => write!(f, "duration"),
             StaticType::DateTime => write!(f, "datetime"),
             StaticType::Timestamp => write!(f, "timestamp"),

--- a/ccc/infrastructure/src/type_checker/ast_type_checker.rs
+++ b/ccc/infrastructure/src/type_checker/ast_type_checker.rs
@@ -17,7 +17,10 @@ fn infer_type(expression: &Expression) -> Result<StaticType, CccError> {
     match expression {
         Expression::Integer(_) => Ok(StaticType::Integer),
         Expression::Float(_) => Ok(StaticType::Float),
-        Expression::List(_) => Ok(StaticType::List),
+        Expression::List(elements) => {
+            infer_list_type(elements)?;
+            Ok(StaticType::List)
+        }
         Expression::DurationTime { .. } => Ok(StaticType::DurationTime),
         Expression::DateTime { .. } => Ok(StaticType::DateTime),
 
@@ -53,6 +56,24 @@ fn infer_type(expression: &Expression) -> Result<StaticType, CccError> {
             infer_function_return_type(name, &arg_types)
         }
     }
+}
+
+/// Validate that all elements of a list have the same type.
+fn infer_list_type(elements: &[Expression]) -> Result<(), CccError> {
+    let first = match elements.first() {
+        None => return Ok(()),
+        Some(e) => e,
+    };
+    let expected = infer_type(first)?;
+    for (i, elem) in elements.iter().enumerate().skip(1) {
+        let actual = infer_type(elem)?;
+        if actual != expected {
+            return Err(CccError::type_check(format!(
+                "list elements must be the same type, expected {expected} at index 0 but found {actual} at index {}", i
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Determine the result type of a binary operation, or error if unsupported.

--- a/ccc/infrastructure/src/type_checker/ast_type_checker.rs
+++ b/ccc/infrastructure/src/type_checker/ast_type_checker.rs
@@ -18,8 +18,8 @@ fn infer_type(expression: &Expression) -> Result<StaticType, CccError> {
         Expression::Integer(_) => Ok(StaticType::Integer),
         Expression::Float(_) => Ok(StaticType::Float),
         Expression::List(elements) => {
-            infer_list_type(elements)?;
-            Ok(StaticType::List)
+            let elem_type = infer_list_element_type(elements)?;
+            Ok(StaticType::List(elem_type.map(Box::new)))
         }
         Expression::DurationTime { .. } => Ok(StaticType::DurationTime),
         Expression::DateTime { .. } => Ok(StaticType::DateTime),
@@ -58,10 +58,11 @@ fn infer_type(expression: &Expression) -> Result<StaticType, CccError> {
     }
 }
 
-/// Validate that all elements of a list have the same type.
-fn infer_list_type(elements: &[Expression]) -> Result<(), CccError> {
+/// Validate that all elements of a list share the same type and return it.
+/// Returns `None` for empty lists.
+fn infer_list_element_type(elements: &[Expression]) -> Result<Option<StaticType>, CccError> {
     let first = match elements.first() {
-        None => return Ok(()),
+        None => return Ok(None),
         Some(e) => e,
     };
     let expected = infer_type(first)?;
@@ -73,7 +74,7 @@ fn infer_list_type(elements: &[Expression]) -> Result<(), CccError> {
             )));
         }
     }
-    Ok(())
+    Ok(Some(expected))
 }
 
 /// Determine the result type of a binary operation, or error if unsupported.
@@ -152,17 +153,17 @@ fn infer_function_return_type(
         // List functions
         "len" => {
             check_arg_count(name, arg_types, 1)?;
-            require_type(name, &arg_types[0], &StaticType::List)?;
+            require_list(name, &arg_types[0])?;
             Ok(StaticType::Integer)
         }
         "sum" | "prod" | "mean" | "var" | "max" | "min" | "median" => {
             check_arg_count(name, arg_types, 1)?;
-            require_type(name, &arg_types[0], &StaticType::List)?;
-            Ok(StaticType::Unknown) // element type unknown at static level
+            require_list(name, &arg_types[0])?;
+            Ok(StaticType::Unknown)
         }
         "head" | "tail" => {
             check_arg_count(name, arg_types, 1)?;
-            require_type(name, &arg_types[0], &StaticType::List)?;
+            require_list(name, &arg_types[0])?;
             Ok(StaticType::Unknown)
         }
 
@@ -241,6 +242,15 @@ fn require_numeric(name: &str, t: &StaticType) -> Result<(), CccError> {
         StaticType::Integer | StaticType::Float | StaticType::Unknown => Ok(()),
         _ => Err(CccError::type_check(format!(
             "{name}: expected numeric argument, got {t}"
+        ))),
+    }
+}
+
+fn require_list(name: &str, actual: &StaticType) -> Result<(), CccError> {
+    match actual {
+        StaticType::List(_) | StaticType::Unknown => Ok(()),
+        _ => Err(CccError::type_check(format!(
+            "{name}: expected list, got {actual}"
         ))),
     }
 }

--- a/ccc/infrastructure/src/type_checker/ast_type_checker.rs
+++ b/ccc/infrastructure/src/type_checker/ast_type_checker.rs
@@ -70,7 +70,8 @@ fn infer_list_element_type(elements: &[Expression]) -> Result<Option<StaticType>
         let actual = infer_type(elem)?;
         if actual != expected {
             return Err(CccError::type_check(format!(
-                "list elements must be the same type, expected {expected} at index 0 but found {actual} at index {}", i
+                "list elements must be the same type, expected {expected} at index 0 but found {actual} at index {}",
+                i
             )));
         }
     }

--- a/ccc/infrastructure/src/type_checker/ast_type_checker_test.rs
+++ b/ccc/infrastructure/src/type_checker/ast_type_checker_test.rs
@@ -32,6 +32,82 @@ mod tests {
     }
 
     #[test]
+    fn list_homogeneous_integers_passes() {
+        // Arrange
+        let expr = Expression::List(vec![
+            Expression::Integer(1),
+            Expression::Integer(2),
+            Expression::Integer(3),
+        ]);
+
+        // Act & Assert
+        assert!(check(expr).is_ok());
+    }
+
+    #[test]
+    fn list_homogeneous_floats_passes() {
+        // Arrange
+        let expr = Expression::List(vec![Expression::Float(1.0), Expression::Float(2.0)]);
+
+        // Act & Assert
+        assert!(check(expr).is_ok());
+    }
+
+    #[test]
+    fn list_homogeneous_durations_passes() {
+        // Arrange
+        let expr = Expression::List(vec![
+            Expression::DurationTime {
+                hours: 0,
+                minutes: 10,
+                seconds: 0,
+            },
+            Expression::DurationTime {
+                hours: 0,
+                minutes: 20,
+                seconds: 0,
+            },
+        ]);
+
+        // Act & Assert
+        assert!(check(expr).is_ok());
+    }
+
+    #[test]
+    fn list_empty_passes() {
+        // Arrange
+        let expr = Expression::List(vec![]);
+
+        // Act & Assert
+        assert!(check(expr).is_ok());
+    }
+
+    #[test]
+    fn list_mixed_integer_float_is_error() {
+        // Arrange
+        let expr = Expression::List(vec![Expression::Integer(1), Expression::Float(2.0)]);
+
+        // Act & Assert
+        assert!(check(expr).is_err());
+    }
+
+    #[test]
+    fn list_mixed_integer_duration_is_error() {
+        // Arrange
+        let expr = Expression::List(vec![
+            Expression::Integer(1),
+            Expression::DurationTime {
+                hours: 0,
+                minutes: 10,
+                seconds: 0,
+            },
+        ]);
+
+        // Act & Assert
+        assert!(check(expr).is_err());
+    }
+
+    #[test]
     fn duration_literal_passes() {
         // Arrange & Act & Assert
         assert!(

--- a/ccc/presentation/tests/cli_test.rs
+++ b/ccc/presentation/tests/cli_test.rs
@@ -292,9 +292,9 @@ fn mixed_type_list_fails() {
     let result = cmd.arg("[1, 2.0, 3]").assert();
 
     // Assert
-    result
-        .failure()
-        .stderr(predicate::str::contains("list elements must be the same type"));
+    result.failure().stderr(predicate::str::contains(
+        "list elements must be the same type",
+    ));
 }
 
 #[test]

--- a/ccc/presentation/tests/cli_test.rs
+++ b/ccc/presentation/tests/cli_test.rs
@@ -284,6 +284,20 @@ fn invalid_expression_fails() {
 }
 
 #[test]
+fn mixed_type_list_fails() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("[1, 2.0, 3]").assert();
+
+    // Assert
+    result
+        .failure()
+        .stderr(predicate::str::contains("list elements must be the same type"));
+}
+
+#[test]
 fn unknown_function_fails() {
     // Arrange
     let mut cmd = ccc();


### PR DESCRIPTION
## Summary

- 型チェッカーの `infer_type` で List 要素の型を検証する `infer_list_type` を追加
- 先頭要素の型を基準に、異なる型が混在する場合は型エラーを返す
- 空リストは許容

## Test plan

- [x] 型チェッカーテスト: 同一型リスト (int, float, duration) → OK
- [x] 型チェッカーテスト: 空リスト → OK
- [x] 型チェッカーテスト: int + float 混在 → エラー
- [x] 型チェッカーテスト: int + duration 混在 → エラー
- [x] CLI テスト: `[1, 2.0, 3]` → エラー
- [x] 全331テスト通過
- [x] 複雑度: 33.07 → 37.01

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)