### PR TITLE
Support method chain syntax for list functions

### DIFF
--- a/ccc/infrastructure/src/parser/grammar.pest
+++ b/ccc/infrastructure/src/parser/grammar.pest
@@ -4,7 +4,11 @@ term = { power ~ (multiplicative_operator ~ power)* }
 
 power = { unary ~ (power_operator ~ unary)* }
 
-unary = { unary_operator? ~ atom }
+unary = { unary_operator? ~ postfix }
+
+postfix = { atom ~ method_call* }
+
+method_call = { "." ~ identifier ~ "(" ~ arguments ~ ")" }
 
 atom = { function_call | datetime_literal | duration_literal | number | list | "(" ~ expression ~ ")" }
 

--- a/ccc/infrastructure/src/parser/pest_based_parser.rs
+++ b/ccc/infrastructure/src/parser/pest_based_parser.rs
@@ -43,6 +43,7 @@ impl PestBasedParser {
             Rule::term => Self::build_binary_expression(pair, Self::to_multiplicative_operation),
             Rule::power => Self::build_right_associative_expression(pair),
             Rule::unary => Self::build_unary(pair),
+            Rule::postfix => Self::build_postfix(pair),
             Rule::atom => Self::build_atom(pair),
             Rule::number => Self::build_number(pair),
             Rule::function_call => Self::build_function_call(pair),
@@ -137,6 +138,33 @@ impl PestBasedParser {
         } else {
             Self::build_expression(first)
         }
+    }
+
+    fn build_postfix(pair: pest::iterators::Pair<Rule>) -> Result<Expression, CccError> {
+        let mut inner = pair.into_inner();
+        let first = inner
+            .next()
+            .ok_or_else(|| CccError::parse("expected expression".to_string()))?;
+        let mut receiver = Self::build_expression(first)?;
+
+        // Desugar each .method(args) into FunctionCall { name, arguments: [receiver, ...args] }
+        for method_pair in inner {
+            let mut method_inner = method_pair.into_inner();
+            let name = method_inner
+                .next()
+                .ok_or_else(|| CccError::parse("expected method name".to_string()))?
+                .as_str()
+                .to_string();
+            let mut arguments = vec![receiver];
+            if let Some(args_pair) = method_inner.next() {
+                for arg in args_pair.into_inner() {
+                    arguments.push(Self::build_expression(arg)?);
+                }
+            }
+            receiver = Expression::FunctionCall { name, arguments };
+        }
+
+        Ok(receiver)
     }
 
     fn build_atom(pair: pest::iterators::Pair<Rule>) -> Result<Expression, CccError> {
@@ -335,6 +363,8 @@ impl PestBasedParser {
             Rule::term => "term",
             Rule::power => "expression",
             Rule::unary => "number, function call, list, or '('",
+            Rule::postfix => "number, function call, list, or '('",
+            Rule::method_call => ".method()",
             Rule::atom => "number, datetime, duration, function call, list, or '('",
             Rule::datetime_literal => "datetime (YYYY-MM-DDTHH:MM:SS)",
             Rule::timezone_offset => "timezone offset",

--- a/ccc/infrastructure/src/parser/pest_based_parser_test.rs
+++ b/ccc/infrastructure/src/parser/pest_based_parser_test.rs
@@ -1012,4 +1012,53 @@ mod tests {
             }
         );
     }
+
+    // --- Method chain syntax ---
+
+    #[test]
+    fn parse_method_call_sum() {
+        // Arrange: [1, 2, 3].sum() desugars to sum([1, 2, 3])
+        let input = "[1, 2, 3].sum()";
+
+        // Act
+        let result = parse_expr(input);
+
+        // Assert
+        assert_eq!(
+            result,
+            Expression::FunctionCall {
+                name: "sum".to_string(),
+                arguments: vec![Expression::List(vec![
+                    Expression::Integer(1),
+                    Expression::Integer(2),
+                    Expression::Integer(3),
+                ])],
+            }
+        );
+    }
+
+    #[test]
+    fn parse_method_chain_multiple() {
+        // Arrange: [1, 2, 3].tail().sum() desugars to sum(tail([1, 2, 3]))
+        let input = "[1, 2, 3].tail().sum()";
+
+        // Act
+        let result = parse_expr(input);
+
+        // Assert
+        assert_eq!(
+            result,
+            Expression::FunctionCall {
+                name: "sum".to_string(),
+                arguments: vec![Expression::FunctionCall {
+                    name: "tail".to_string(),
+                    arguments: vec![Expression::List(vec![
+                        Expression::Integer(1),
+                        Expression::Integer(2),
+                        Expression::Integer(3),
+                    ])],
+                }],
+            }
+        );
+    }
 }

--- a/ccc/presentation/tests/cli_test.rs
+++ b/ccc/presentation/tests/cli_test.rs
@@ -1076,3 +1076,65 @@ fn repl_subcommand_exists() {
     // Assert
     result.success();
 }
+
+// --- Method chain ---
+
+#[test]
+fn evaluate_method_chain_sum() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("[1, 2, 3].sum()").assert();
+
+    // Assert
+    result.success().stdout("6\n");
+}
+
+#[test]
+fn evaluate_method_chain_len() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("[1, 2, 3].len()").assert();
+
+    // Assert
+    result.success().stdout("3\n");
+}
+
+#[test]
+fn evaluate_method_chain_head() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("[10, 20, 30].head()").assert();
+
+    // Assert
+    result.success().stdout("10\n");
+}
+
+#[test]
+fn evaluate_method_chain_chained() {
+    // Arrange: [1, 2, 3].tail().sum() = sum(tail([1, 2, 3])) = sum([2, 3]) = 5
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("[1, 2, 3].tail().sum()").assert();
+
+    // Assert
+    result.success().stdout("5\n");
+}
+
+#[test]
+fn evaluate_method_chain_mean() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("[2, 4, 6].mean()").assert();
+
+    // Assert
+    result.success().stdout("4\n");
+}


### PR DESCRIPTION
## Summary

- grammar に `postfix` / `method_call` ルールを追加
- パース時に `.method(args)` を `FunctionCall { name, arguments: [receiver, ...args] }` に脱糖
- AST 変更なし、型チェッカー・評価器の変更なし
- 全既存リスト関数（sum, len, head, tail, mean, var, max, min, median, prod）がメソッドチェーンで呼べる

## 使用例

```
$ ccc "[1, 2, 3].sum()"
6

$ ccc "[1, 2, 3].tail().sum()"
5

$ ccc "[2, 4, 6].mean()"
4
```

## Test plan

- [x] パーサーテスト: `.sum()` の脱糖
- [x] パーサーテスト: `.tail().sum()` の連鎖脱糖
- [x] CLI テスト: `.sum()`, `.len()`, `.head()`, `.mean()`
- [x] CLI テスト: `.tail().sum()` のチェーン
- [x] 全338テスト通過
- [x] 複雑度: 52.29 → 55.73

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)