### PR TITLE
Add type cast operator (as int, as float)

### DIFF
--- a/ccc/domain/src/ast.rs
+++ b/ccc/domain/src/ast.rs
@@ -1,3 +1,10 @@
+/// Target type for `as` type cast expressions.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CastTargetType {
+    Integer,
+    Float,
+}
+
 /// Binary operators.
 #[derive(Debug, Clone, PartialEq)]
 pub enum BinaryOperation {
@@ -35,6 +42,11 @@ pub enum Expression {
         arguments: Vec<Expression>,
     },
     List(Vec<Expression>),
+    /// Type cast expression: `<expr> as int` or `<expr> as float`.
+    TypeCast {
+        operand: Box<Expression>,
+        target_type: CastTargetType,
+    },
     /// Duration literal parsed from `HH:MM:SS` syntax.
     DurationTime {
         hours: i64,

--- a/ccc/infrastructure/src/evaluator/ast_evaluator.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator.rs
@@ -1,4 +1,4 @@
-use domain::ast::{AbstractSyntaxTree, BinaryOperation, Expression, UnaryOperation};
+use domain::ast::{AbstractSyntaxTree, BinaryOperation, CastTargetType, Expression, UnaryOperation};
 use domain::error::CccError;
 use domain::interface::evaluator::CccEvaluator;
 use domain::value::Value;
@@ -34,6 +34,13 @@ fn evaluate_expression(expression: &Expression) -> Result<Value, CccError> {
             let evaluated_arguments: Result<Vec<Value>, CccError> =
                 arguments.iter().map(evaluate_expression).collect();
             builtin::call_builtin(name, &evaluated_arguments?)
+        }
+        Expression::TypeCast {
+            operand,
+            target_type,
+        } => {
+            let value = evaluate_expression(operand)?;
+            evaluate_type_cast(&value, target_type)
         }
         Expression::List(elements) => {
             let evaluated: Result<Vec<Value>, CccError> =
@@ -263,6 +270,19 @@ fn evaluate_unary(operator: &UnaryOperation, value: &Value) -> Result<Value, Ccc
     }
 }
 
+fn evaluate_type_cast(value: &Value, target_type: &CastTargetType) -> Result<Value, CccError> {
+    match target_type {
+        CastTargetType::Integer => {
+            let n = to_i64(value)?;
+            Ok(Value::Integer(n))
+        }
+        CastTargetType::Float => {
+            let n = to_f64(value)?;
+            Ok(Value::Float(n))
+        }
+    }
+}
+
 fn to_f64(value: &Value) -> Result<f64, CccError> {
     match value {
         Value::Integer(n) => Ok(*n as f64),
@@ -274,7 +294,6 @@ fn to_f64(value: &Value) -> Result<f64, CccError> {
     }
 }
 
-#[allow(dead_code)]
 fn to_i64(value: &Value) -> Result<i64, CccError> {
     match value {
         Value::Integer(n) => Ok(*n),

--- a/ccc/infrastructure/src/evaluator/ast_evaluator.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator.rs
@@ -1,4 +1,6 @@
-use domain::ast::{AbstractSyntaxTree, BinaryOperation, CastTargetType, Expression, UnaryOperation};
+use domain::ast::{
+    AbstractSyntaxTree, BinaryOperation, CastTargetType, Expression, UnaryOperation,
+};
 use domain::error::CccError;
 use domain::interface::evaluator::CccEvaluator;
 use domain::value::Value;

--- a/ccc/infrastructure/src/evaluator/ast_evaluator_test.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator_test.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use domain::ast::{AbstractSyntaxTree, BinaryOperation, CastTargetType, Expression, UnaryOperation};
+    use domain::ast::{
+        AbstractSyntaxTree, BinaryOperation, CastTargetType, Expression, UnaryOperation,
+    };
     use domain::error::CccError;
     use domain::interface::evaluator::CccEvaluator;
     use domain::value::Value;

--- a/ccc/infrastructure/src/evaluator/ast_evaluator_test.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use domain::ast::{AbstractSyntaxTree, BinaryOperation, Expression, UnaryOperation};
+    use domain::ast::{AbstractSyntaxTree, BinaryOperation, CastTargetType, Expression, UnaryOperation};
     use domain::error::CccError;
     use domain::interface::evaluator::CccEvaluator;
     use domain::value::Value;
@@ -371,6 +371,141 @@ mod tests {
 
         // Assert
         assert_eq!(result.unwrap(), Value::Integer(7));
+    }
+
+    // --- Type cast ---
+
+    #[test]
+    fn cast_integer_to_float() {
+        // Arrange: 3 as float → 3.0
+        let expression = Expression::TypeCast {
+            operand: Box::new(Expression::Integer(3)),
+            target_type: CastTargetType::Float,
+        };
+
+        // Act
+        let result = eval(expression);
+
+        // Assert
+        assert_eq!(result.unwrap(), Value::Float(3.0));
+    }
+
+    #[test]
+    fn cast_zero_to_float() {
+        // Arrange: 0 as float → 0.0
+        let expression = Expression::TypeCast {
+            operand: Box::new(Expression::Integer(0)),
+            target_type: CastTargetType::Float,
+        };
+
+        // Act
+        let result = eval(expression);
+
+        // Assert
+        assert_eq!(result.unwrap(), Value::Float(0.0));
+    }
+
+    #[test]
+    fn cast_negative_integer_to_float() {
+        // Arrange: -5 as float → -5.0
+        let expression = Expression::TypeCast {
+            operand: Box::new(Expression::UnaryOperation {
+                operator: UnaryOperation::Negate,
+                operand: Box::new(Expression::Integer(5)),
+            }),
+            target_type: CastTargetType::Float,
+        };
+
+        // Act
+        let result = eval(expression);
+
+        // Assert
+        assert_eq!(result.unwrap(), Value::Float(-5.0));
+    }
+
+    #[test]
+    fn cast_float_to_int_truncates() {
+        // Arrange: 3.7 as int → 3
+        let expression = Expression::TypeCast {
+            operand: Box::new(Expression::Float(3.7)),
+            target_type: CastTargetType::Integer,
+        };
+
+        // Act
+        let result = eval(expression);
+
+        // Assert
+        assert_eq!(result.unwrap(), Value::Integer(3));
+    }
+
+    #[test]
+    fn cast_negative_float_to_int_truncates_toward_zero() {
+        // Arrange: -2.9 as int → -2
+        let expression = Expression::TypeCast {
+            operand: Box::new(Expression::UnaryOperation {
+                operator: UnaryOperation::Negate,
+                operand: Box::new(Expression::Float(2.9)),
+            }),
+            target_type: CastTargetType::Integer,
+        };
+
+        // Act
+        let result = eval(expression);
+
+        // Assert
+        assert_eq!(result.unwrap(), Value::Integer(-2));
+    }
+
+    #[test]
+    fn cast_zero_float_to_int() {
+        // Arrange: 0.0 as int → 0
+        let expression = Expression::TypeCast {
+            operand: Box::new(Expression::Float(0.0)),
+            target_type: CastTargetType::Integer,
+        };
+
+        // Act
+        let result = eval(expression);
+
+        // Assert
+        assert_eq!(result.unwrap(), Value::Integer(0));
+    }
+
+    #[test]
+    fn cast_integer_to_int_is_identity() {
+        // Arrange: 3 as int → 3
+        let expression = Expression::TypeCast {
+            operand: Box::new(Expression::Integer(3)),
+            target_type: CastTargetType::Integer,
+        };
+
+        // Act
+        let result = eval(expression);
+
+        // Assert
+        assert_eq!(result.unwrap(), Value::Integer(3));
+    }
+
+    #[test]
+    fn cast_expression_result_to_int() {
+        // Arrange: E([1, 2, 3]) as int → mean([1,2,3]) = 2.0 → 2
+        let expression = Expression::TypeCast {
+            operand: Box::new(Expression::FunctionCall {
+                name: "mean".to_string(),
+                arguments: vec![Expression::List(vec![
+                    Expression::Integer(1),
+                    Expression::Integer(2),
+                    Expression::Integer(3),
+                ])],
+            }),
+            target_type: CastTargetType::Integer,
+        };
+
+        // Act
+        let result = eval(expression);
+
+        // Assert
+        assert_eq!(result.unwrap(), Value::Integer(2));
     }
 
     // --- Builtin functions ---

--- a/ccc/infrastructure/src/parser/grammar.pest
+++ b/ccc/infrastructure/src/parser/grammar.pest
@@ -6,9 +6,14 @@ power = { unary ~ (power_operator ~ unary)* }
 
 unary = { unary_operator? ~ postfix }
 
-postfix = { atom ~ method_call* }
+postfix = { atom ~ postfix_suffix* }
+
+postfix_suffix = { method_call | type_cast }
 
 method_call = { "." ~ identifier ~ "(" ~ arguments ~ ")" }
+
+type_cast = { "as" ~ cast_type }
+cast_type = @{ "int" | "float" }
 
 atom = { function_call | datetime_literal | duration_literal | number | list | "(" ~ expression ~ ")" }
 

--- a/ccc/infrastructure/src/parser/pest_based_parser.rs
+++ b/ccc/infrastructure/src/parser/pest_based_parser.rs
@@ -1,7 +1,7 @@
 use pest::Parser as PestParserTrait;
 use pest_derive::Parser as PestDerive;
 
-use domain::ast::{AbstractSyntaxTree, BinaryOperation, Expression, UnaryOperation};
+use domain::ast::{AbstractSyntaxTree, BinaryOperation, CastTargetType, Expression, UnaryOperation};
 use domain::error::CccError;
 use domain::interface::parser::CccParser;
 
@@ -147,24 +147,70 @@ impl PestBasedParser {
             .ok_or_else(|| CccError::parse("expected expression".to_string()))?;
         let mut receiver = Self::build_expression(first)?;
 
-        // Desugar each .method(args) into FunctionCall { name, arguments: [receiver, ...args] }
-        for method_pair in inner {
-            let mut method_inner = method_pair.into_inner();
-            let name = method_inner
+        for suffix_pair in inner {
+            let suffix_inner = suffix_pair
+                .into_inner()
                 .next()
-                .ok_or_else(|| CccError::parse("expected method name".to_string()))?
-                .as_str()
-                .to_string();
-            let mut arguments = vec![receiver];
-            if let Some(args_pair) = method_inner.next() {
-                for arg in args_pair.into_inner() {
-                    arguments.push(Self::build_expression(arg)?);
+                .ok_or_else(|| CccError::parse("expected postfix suffix".to_string()))?;
+            match suffix_inner.as_rule() {
+                Rule::method_call => {
+                    receiver = Self::build_method_call(receiver, suffix_inner)?;
+                }
+                Rule::type_cast => {
+                    receiver = Self::build_type_cast(receiver, suffix_inner)?;
+                }
+                _ => {
+                    return Err(CccError::parse(format!(
+                        "unexpected postfix rule: {:?}",
+                        suffix_inner.as_rule()
+                    )));
                 }
             }
-            receiver = Expression::FunctionCall { name, arguments };
         }
 
         Ok(receiver)
+    }
+
+    fn build_method_call(
+        receiver: Expression,
+        pair: pest::iterators::Pair<Rule>,
+    ) -> Result<Expression, CccError> {
+        let mut method_inner = pair.into_inner();
+        let name = method_inner
+            .next()
+            .ok_or_else(|| CccError::parse("expected method name".to_string()))?
+            .as_str()
+            .to_string();
+        let mut arguments = vec![receiver];
+        if let Some(args_pair) = method_inner.next() {
+            for arg in args_pair.into_inner() {
+                arguments.push(Self::build_expression(arg)?);
+            }
+        }
+        Ok(Expression::FunctionCall { name, arguments })
+    }
+
+    fn build_type_cast(
+        operand: Expression,
+        pair: pest::iterators::Pair<Rule>,
+    ) -> Result<Expression, CccError> {
+        let cast_type_pair = pair
+            .into_inner()
+            .next()
+            .ok_or_else(|| CccError::parse("expected cast target type".to_string()))?;
+        let target_type = match cast_type_pair.as_str() {
+            "int" => CastTargetType::Integer,
+            "float" => CastTargetType::Float,
+            other => {
+                return Err(CccError::parse(format!(
+                    "unsupported cast target type: {other}"
+                )));
+            }
+        };
+        Ok(Expression::TypeCast {
+            operand: Box::new(operand),
+            target_type,
+        })
     }
 
     fn build_atom(pair: pest::iterators::Pair<Rule>) -> Result<Expression, CccError> {
@@ -364,7 +410,10 @@ impl PestBasedParser {
             Rule::power => "expression",
             Rule::unary => "number, function call, list, or '('",
             Rule::postfix => "number, function call, list, or '('",
+            Rule::postfix_suffix => "'as' or '.method()'",
             Rule::method_call => ".method()",
+            Rule::type_cast => "'as int' or 'as float'",
+            Rule::cast_type => "'int' or 'float'",
             Rule::atom => "number, datetime, duration, function call, list, or '('",
             Rule::datetime_literal => "datetime (YYYY-MM-DDTHH:MM:SS)",
             Rule::timezone_offset => "timezone offset",

--- a/ccc/infrastructure/src/parser/pest_based_parser.rs
+++ b/ccc/infrastructure/src/parser/pest_based_parser.rs
@@ -1,7 +1,9 @@
 use pest::Parser as PestParserTrait;
 use pest_derive::Parser as PestDerive;
 
-use domain::ast::{AbstractSyntaxTree, BinaryOperation, CastTargetType, Expression, UnaryOperation};
+use domain::ast::{
+    AbstractSyntaxTree, BinaryOperation, CastTargetType, Expression, UnaryOperation,
+};
 use domain::error::CccError;
 use domain::interface::parser::CccParser;
 

--- a/ccc/infrastructure/src/parser/pest_based_parser_test.rs
+++ b/ccc/infrastructure/src/parser/pest_based_parser_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use domain::ast::{BinaryOperation, Expression, UnaryOperation};
+    use domain::ast::{BinaryOperation, CastTargetType, Expression, UnaryOperation};
     use domain::interface::parser::CccParser;
 
     use crate::parser::PestBasedParser;
@@ -1009,6 +1009,114 @@ mod tests {
                 minute: 0,
                 second: 0,
                 offset_seconds: 0,
+            }
+        );
+    }
+
+    // --- Type cast syntax ---
+
+    #[test]
+    fn parse_integer_as_float() {
+        // Arrange
+        let input = "3 as float";
+
+        // Act
+        let result = parse_expr(input);
+
+        // Assert
+        assert_eq!(
+            result,
+            Expression::TypeCast {
+                operand: Box::new(Expression::Integer(3)),
+                target_type: CastTargetType::Float,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_float_as_int() {
+        // Arrange
+        let input = "3.7 as int";
+
+        // Act
+        let result = parse_expr(input);
+
+        // Assert
+        assert_eq!(
+            result,
+            Expression::TypeCast {
+                operand: Box::new(Expression::Float(3.7)),
+                target_type: CastTargetType::Integer,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_expression_result_as_int() {
+        // Arrange: (1 + 2) as int
+        let input = "(1 + 2) as int";
+
+        // Act
+        let result = parse_expr(input);
+
+        // Assert
+        assert_eq!(
+            result,
+            Expression::TypeCast {
+                operand: Box::new(Expression::BinaryOperation {
+                    operator: BinaryOperation::Add,
+                    left: Box::new(Expression::Integer(1)),
+                    right: Box::new(Expression::Integer(2)),
+                }),
+                target_type: CastTargetType::Integer,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_cast_in_binary_expression() {
+        // Arrange: 2 * 3 as float + 1 → (2 * (3 as float)) + 1
+        // `as` binds at postfix level (tighter than multiplicative)
+        let input = "2 * 3 as float + 1";
+
+        // Act
+        let result = parse_expr(input);
+
+        // Assert
+        assert_eq!(
+            result,
+            Expression::BinaryOperation {
+                operator: BinaryOperation::Add,
+                left: Box::new(Expression::BinaryOperation {
+                    operator: BinaryOperation::Multiply,
+                    left: Box::new(Expression::Integer(2)),
+                    right: Box::new(Expression::TypeCast {
+                        operand: Box::new(Expression::Integer(3)),
+                        target_type: CastTargetType::Float,
+                    }),
+                }),
+                right: Box::new(Expression::Integer(1)),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_chained_cast() {
+        // Arrange: 42 as float as int
+        let input = "42 as float as int";
+
+        // Act
+        let result = parse_expr(input);
+
+        // Assert
+        assert_eq!(
+            result,
+            Expression::TypeCast {
+                operand: Box::new(Expression::TypeCast {
+                    operand: Box::new(Expression::Integer(42)),
+                    target_type: CastTargetType::Float,
+                }),
+                target_type: CastTargetType::Integer,
             }
         );
     }

--- a/ccc/infrastructure/src/type_checker/ast_type_checker.rs
+++ b/ccc/infrastructure/src/type_checker/ast_type_checker.rs
@@ -1,4 +1,4 @@
-use domain::ast::{AbstractSyntaxTree, BinaryOperation, Expression};
+use domain::ast::{AbstractSyntaxTree, BinaryOperation, CastTargetType, Expression};
 use domain::error::CccError;
 use domain::interface::type_checker::CccTypeChecker;
 use domain::static_type::StaticType;
@@ -47,6 +47,24 @@ fn infer_type(expression: &Expression) -> Result<StaticType, CccError> {
             let left_type = infer_type(left)?;
             let right_type = infer_type(right)?;
             infer_binary_type(operator, &left_type, &right_type)
+        }
+
+        Expression::TypeCast {
+            operand,
+            target_type,
+        } => {
+            let operand_type = infer_type(operand)?;
+            match operand_type {
+                StaticType::Integer | StaticType::Float | StaticType::Unknown => {
+                    match target_type {
+                        CastTargetType::Integer => Ok(StaticType::Integer),
+                        CastTargetType::Float => Ok(StaticType::Float),
+                    }
+                }
+                _ => Err(CccError::type_check(format!(
+                    "cannot cast {operand_type} with 'as'"
+                ))),
+            }
         }
 
         Expression::FunctionCall { name, arguments } => {

--- a/ccc/infrastructure/src/type_checker/ast_type_checker_test.rs
+++ b/ccc/infrastructure/src/type_checker/ast_type_checker_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use domain::ast::{AbstractSyntaxTree, BinaryOperation, Expression, UnaryOperation};
+    use domain::ast::{AbstractSyntaxTree, BinaryOperation, CastTargetType, Expression, UnaryOperation};
     use domain::interface::type_checker::CccTypeChecker;
 
     use crate::type_checker::AstTypeChecker;
@@ -135,6 +135,104 @@ mod tests {
             })
             .is_ok()
         );
+    }
+
+    // --- Type cast ---
+
+    #[test]
+    fn cast_integer_to_float_passes() {
+        // Arrange
+        let expr = Expression::TypeCast {
+            operand: Box::new(Expression::Integer(3)),
+            target_type: CastTargetType::Float,
+        };
+
+        // Act & Assert
+        assert!(check(expr).is_ok());
+    }
+
+    #[test]
+    fn cast_float_to_int_passes() {
+        // Arrange
+        let expr = Expression::TypeCast {
+            operand: Box::new(Expression::Float(3.7)),
+            target_type: CastTargetType::Integer,
+        };
+
+        // Act & Assert
+        assert!(check(expr).is_ok());
+    }
+
+    #[test]
+    fn cast_integer_to_int_passes() {
+        // Arrange
+        let expr = Expression::TypeCast {
+            operand: Box::new(Expression::Integer(3)),
+            target_type: CastTargetType::Integer,
+        };
+
+        // Act & Assert
+        assert!(check(expr).is_ok());
+    }
+
+    #[test]
+    fn cast_float_to_float_passes() {
+        // Arrange
+        let expr = Expression::TypeCast {
+            operand: Box::new(Expression::Float(3.0)),
+            target_type: CastTargetType::Float,
+        };
+
+        // Act & Assert
+        assert!(check(expr).is_ok());
+    }
+
+    #[test]
+    fn cast_duration_to_int_is_error() {
+        // Arrange
+        let expr = Expression::TypeCast {
+            operand: Box::new(Expression::DurationTime {
+                hours: 0,
+                minutes: 10,
+                seconds: 0,
+            }),
+            target_type: CastTargetType::Integer,
+        };
+
+        // Act & Assert
+        assert!(check(expr).is_err());
+    }
+
+    #[test]
+    fn cast_datetime_to_int_is_error() {
+        // Arrange
+        let expr = Expression::TypeCast {
+            operand: Box::new(Expression::DateTime {
+                year: 2026,
+                month: 1,
+                day: 1,
+                hour: 0,
+                minute: 0,
+                second: 0,
+                offset_seconds: 0,
+            }),
+            target_type: CastTargetType::Integer,
+        };
+
+        // Act & Assert
+        assert!(check(expr).is_err());
+    }
+
+    #[test]
+    fn cast_list_to_int_is_error() {
+        // Arrange
+        let expr = Expression::TypeCast {
+            operand: Box::new(Expression::List(vec![Expression::Integer(1)])),
+            target_type: CastTargetType::Integer,
+        };
+
+        // Act & Assert
+        assert!(check(expr).is_err());
     }
 
     // --- Valid numeric binary operations ---

--- a/ccc/infrastructure/src/type_checker/ast_type_checker_test.rs
+++ b/ccc/infrastructure/src/type_checker/ast_type_checker_test.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use domain::ast::{AbstractSyntaxTree, BinaryOperation, CastTargetType, Expression, UnaryOperation};
+    use domain::ast::{
+        AbstractSyntaxTree, BinaryOperation, CastTargetType, Expression, UnaryOperation,
+    };
     use domain::interface::type_checker::CccTypeChecker;
 
     use crate::type_checker::AstTypeChecker;

--- a/ccc/presentation/tests/cli_test.rs
+++ b/ccc/presentation/tests/cli_test.rs
@@ -1138,3 +1138,103 @@ fn evaluate_method_chain_mean() {
     // Assert
     result.success().stdout("4\n");
 }
+
+// --- Type cast (as) ---
+
+#[test]
+fn evaluate_integer_as_float() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("3 as float").assert();
+
+    // Assert
+    result.success().stdout("3\n");
+}
+
+#[test]
+fn evaluate_zero_as_float() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("0 as float").assert();
+
+    // Assert
+    result.success().stdout("0\n");
+}
+
+#[test]
+fn evaluate_float_as_int() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("3.7 as int").assert();
+
+    // Assert
+    result.success().stdout("3\n");
+}
+
+#[test]
+fn evaluate_negative_float_as_int() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.args(["--", "-2.9 as int"]).assert();
+
+    // Assert
+    result.success().stdout("-2\n");
+}
+
+#[test]
+fn evaluate_zero_float_as_int() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("0.0 as int").assert();
+
+    // Assert
+    result.success().stdout("0\n");
+}
+
+#[test]
+fn evaluate_integer_as_int() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("3 as int").assert();
+
+    // Assert
+    result.success().stdout("3\n");
+}
+
+#[test]
+fn evaluate_mean_as_int() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("mean([1, 2, 3]) as int").assert();
+
+    // Assert
+    result.success().stdout("2\n");
+}
+
+#[test]
+fn evaluate_duration_as_int_fails() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("0:10:00 as int").assert();
+
+    // Assert
+    result
+        .failure()
+        .stderr(predicate::str::contains("cannot cast"));
+}


### PR DESCRIPTION
## Summary

- `as int` / `as float` 後置演算子を追加し、数値型間の明示的な型変換を可能にした
- grammar.pest に `type_cast` ルールを postfix レベルで追加（メソッドチェーンと同優先度）
- 型チェッカーで非数値型（duration, datetime, list）からのキャストを型エラーとして拒否

## Test plan

- [x] パーサーテスト: リテラル・式・二項演算中の優先度・チェーンキャストのパース確認
- [x] 型チェッカーテスト: 数値型間のキャスト許可、非数値型のキャスト拒否
- [x] 評価器テスト: int→float, float→int（0方向切り捨て）、同一型、式結果のキャスト
- [x] 統合テスト: `3 as float`, `3.7 as int`, `-2.9 as int`, `mean([1,2,3]) as int`, `0:10:00 as int`（エラー）

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)