### PR TITLE
Replace datetime/timestamp converters with as syntax

### DIFF
--- a/ccc/domain/src/ast.rs
+++ b/ccc/domain/src/ast.rs
@@ -3,6 +3,8 @@
 pub enum CastTargetType {
     Integer,
     Float,
+    Timestamp,
+    DateTime,
 }
 
 /// Binary operators.

--- a/ccc/infrastructure/src/evaluator/ast_evaluator.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator.rs
@@ -282,6 +282,23 @@ fn evaluate_type_cast(value: &Value, target_type: &CastTargetType) -> Result<Val
             let n = to_f64(value)?;
             Ok(Value::Float(n))
         }
+        CastTargetType::Timestamp => match value {
+            Value::DateTime { epoch_seconds, .. } => Ok(Value::Timestamp(*epoch_seconds as f64)),
+            _ => Err(CccError::eval(format!(
+                "cannot cast {} to timestamp",
+                type_name(value)
+            ))),
+        },
+        CastTargetType::DateTime => match value {
+            Value::Timestamp(ts) => Ok(Value::DateTime {
+                epoch_seconds: *ts as i64,
+                offset_seconds: 0,
+            }),
+            _ => Err(CccError::eval(format!(
+                "cannot cast {} to datetime",
+                type_name(value)
+            ))),
+        },
     }
 }
 

--- a/ccc/infrastructure/src/evaluator/ast_evaluator_test.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator_test.rs
@@ -1253,11 +1253,10 @@ mod tests {
     }
 
     #[test]
-    fn eval_to_timestamp_from_datetime() {
-        // Arrange: to_timestamp(DateTime(2026,1,1,0,0,0))
-        let expression = Expression::FunctionCall {
-            name: "datetime_to_timestamp".to_string(),
-            arguments: vec![Expression::FunctionCall {
+    fn cast_datetime_to_timestamp() {
+        // Arrange: DateTime(2026,1,1,0,0,0) as timestamp
+        let expression = Expression::TypeCast {
+            operand: Box::new(Expression::FunctionCall {
                 name: "DateTime".to_string(),
                 arguments: vec![
                     Expression::Integer(2026),
@@ -1267,7 +1266,8 @@ mod tests {
                     Expression::Integer(0),
                     Expression::Integer(0),
                 ],
-            }],
+            }),
+            target_type: CastTargetType::Timestamp,
         };
 
         // Act
@@ -1282,14 +1282,14 @@ mod tests {
     }
 
     #[test]
-    fn eval_to_datetime_from_timestamp() {
-        // Arrange: to_datetime(Timestamp(0))
-        let expression = Expression::FunctionCall {
-            name: "timestamp_to_datetime".to_string(),
-            arguments: vec![Expression::FunctionCall {
+    fn cast_timestamp_to_datetime() {
+        // Arrange: Timestamp(0) as datetime
+        let expression = Expression::TypeCast {
+            operand: Box::new(Expression::FunctionCall {
                 name: "Timestamp".to_string(),
                 arguments: vec![Expression::Integer(0)],
-            }],
+            }),
+            target_type: CastTargetType::DateTime,
         };
 
         // Act
@@ -1301,33 +1301,6 @@ mod tests {
             Value::DateTime {
                 epoch_seconds: 0,
                 offset_seconds: 0,
-            }
-        );
-    }
-
-    #[test]
-    fn eval_to_datetime_with_timezone_offset() {
-        // Arrange: to_datetime(Timestamp(0), 9)
-        let expression = Expression::FunctionCall {
-            name: "timestamp_to_datetime".to_string(),
-            arguments: vec![
-                Expression::FunctionCall {
-                    name: "Timestamp".to_string(),
-                    arguments: vec![Expression::Integer(0)],
-                },
-                Expression::Integer(9),
-            ],
-        };
-
-        // Act
-        let result = eval(expression).unwrap();
-
-        // Assert
-        assert_eq!(
-            result,
-            Value::DateTime {
-                epoch_seconds: 0,
-                offset_seconds: 9 * 3600,
             }
         );
     }
@@ -1667,12 +1640,10 @@ mod tests {
 
     #[test]
     fn eval_round_trip_datetime_timestamp() {
-        // Arrange: to_datetime(to_timestamp(DateTime(2026,6,15,12,30,0)))
-        let expression = Expression::FunctionCall {
-            name: "timestamp_to_datetime".to_string(),
-            arguments: vec![Expression::FunctionCall {
-                name: "datetime_to_timestamp".to_string(),
-                arguments: vec![Expression::FunctionCall {
+        // Arrange: (DateTime(2026,6,15,12,30,0) as timestamp) as datetime
+        let expression = Expression::TypeCast {
+            operand: Box::new(Expression::TypeCast {
+                operand: Box::new(Expression::FunctionCall {
                     name: "DateTime".to_string(),
                     arguments: vec![
                         Expression::Integer(2026),
@@ -1682,8 +1653,10 @@ mod tests {
                         Expression::Integer(30),
                         Expression::Integer(0),
                     ],
-                }],
-            }],
+                }),
+                target_type: CastTargetType::Timestamp,
+            }),
+            target_type: CastTargetType::DateTime,
         };
 
         // Act

--- a/ccc/infrastructure/src/evaluator/builtin.rs
+++ b/ccc/infrastructure/src/evaluator/builtin.rs
@@ -31,8 +31,6 @@ pub fn call_builtin(name: &str, arguments: &[Value]) -> Result<Value, CccError> 
         "DurationTime" => duration_time_constructor(arguments),
         "DateTime" => datetime_constructor(arguments),
         "Timestamp" => timestamp_constructor(arguments),
-        "datetime_to_timestamp" => datetime_to_timestamp(arguments),
-        "timestamp_to_datetime" => timestamp_to_datetime(arguments),
         "now" => now_function(arguments),
         "today" => today_function(arguments),
         "current_timestamp" => current_timestamp_function(arguments),
@@ -421,48 +419,6 @@ fn timestamp_constructor(arguments: &[Value]) -> Result<Value, CccError> {
         Value::Float(n) => Ok(Value::Timestamp(*n)),
         _ => Err(CccError::eval("Timestamp: expected integer or float")),
     }
-}
-
-fn datetime_to_timestamp(arguments: &[Value]) -> Result<Value, CccError> {
-    if arguments.len() != 1 {
-        return Err(CccError::eval(format!(
-            "datetime_to_timestamp expects 1 argument, got {}",
-            arguments.len()
-        )));
-    }
-    match &arguments[0] {
-        Value::DateTime { epoch_seconds, .. } => Ok(Value::Timestamp(*epoch_seconds as f64)),
-        _ => Err(CccError::eval("datetime_to_timestamp: expected datetime")),
-    }
-}
-
-fn timestamp_to_datetime(arguments: &[Value]) -> Result<Value, CccError> {
-    if arguments.is_empty() || arguments.len() > 2 {
-        return Err(CccError::eval(format!(
-            "timestamp_to_datetime expects 1-2 arguments, got {}",
-            arguments.len()
-        )));
-    }
-    let ts = match &arguments[0] {
-        Value::Timestamp(n) => *n,
-        _ => return Err(CccError::eval("timestamp_to_datetime: expected timestamp")),
-    };
-    let offset_seconds = if arguments.len() == 2 {
-        match &arguments[1] {
-            Value::Integer(hours) => (*hours as i32) * 3600,
-            _ => {
-                return Err(CccError::eval(
-                    "timestamp_to_datetime: timezone offset must be integer",
-                ));
-            }
-        }
-    } else {
-        0
-    };
-    Ok(Value::DateTime {
-        epoch_seconds: ts as i64,
-        offset_seconds,
-    })
 }
 
 fn now_function(arguments: &[Value]) -> Result<Value, CccError> {

--- a/ccc/infrastructure/src/parser/grammar.pest
+++ b/ccc/infrastructure/src/parser/grammar.pest
@@ -13,7 +13,7 @@ postfix_suffix = { method_call | type_cast }
 method_call = { "." ~ identifier ~ "(" ~ arguments ~ ")" }
 
 type_cast = { "as" ~ cast_type }
-cast_type = @{ "int" | "float" }
+cast_type = @{ "int" | "float" | "timestamp" | "datetime" }
 
 atom = { function_call | datetime_literal | duration_literal | number | list | "(" ~ expression ~ ")" }
 

--- a/ccc/infrastructure/src/parser/pest_based_parser.rs
+++ b/ccc/infrastructure/src/parser/pest_based_parser.rs
@@ -203,6 +203,8 @@ impl PestBasedParser {
         let target_type = match cast_type_pair.as_str() {
             "int" => CastTargetType::Integer,
             "float" => CastTargetType::Float,
+            "timestamp" => CastTargetType::Timestamp,
+            "datetime" => CastTargetType::DateTime,
             other => {
                 return Err(CccError::parse(format!(
                     "unsupported cast target type: {other}"

--- a/ccc/infrastructure/src/type_checker/ast_type_checker.rs
+++ b/ccc/infrastructure/src/type_checker/ast_type_checker.rs
@@ -54,17 +54,7 @@ fn infer_type(expression: &Expression) -> Result<StaticType, CccError> {
             target_type,
         } => {
             let operand_type = infer_type(operand)?;
-            match operand_type {
-                StaticType::Integer | StaticType::Float | StaticType::Unknown => {
-                    match target_type {
-                        CastTargetType::Integer => Ok(StaticType::Integer),
-                        CastTargetType::Float => Ok(StaticType::Float),
-                    }
-                }
-                _ => Err(CccError::type_check(format!(
-                    "cannot cast {operand_type} with 'as'"
-                ))),
-            }
+            infer_cast_type(&operand_type, target_type)
         }
 
         Expression::FunctionCall { name, arguments } => {
@@ -94,6 +84,42 @@ fn infer_list_element_type(elements: &[Expression]) -> Result<Option<StaticType>
         }
     }
     Ok(Some(expected))
+}
+
+/// Determine the result type of a type cast, or error if unsupported.
+fn infer_cast_type(
+    operand_type: &StaticType,
+    target_type: &CastTargetType,
+) -> Result<StaticType, CccError> {
+    match (operand_type, target_type) {
+        // Numeric casts
+        (StaticType::Integer | StaticType::Float, CastTargetType::Integer) => {
+            Ok(StaticType::Integer)
+        }
+        (StaticType::Integer | StaticType::Float, CastTargetType::Float) => Ok(StaticType::Float),
+        // DateTime → Timestamp
+        (StaticType::DateTime, CastTargetType::Timestamp) => Ok(StaticType::Timestamp),
+        // Timestamp → DateTime
+        (StaticType::Timestamp, CastTargetType::DateTime) => Ok(StaticType::DateTime),
+        // Unknown passes through
+        (StaticType::Unknown, target) => match target {
+            CastTargetType::Integer => Ok(StaticType::Integer),
+            CastTargetType::Float => Ok(StaticType::Float),
+            CastTargetType::Timestamp => Ok(StaticType::Timestamp),
+            CastTargetType::DateTime => Ok(StaticType::DateTime),
+        },
+        _ => {
+            let target_name = match target_type {
+                CastTargetType::Integer => "int",
+                CastTargetType::Float => "float",
+                CastTargetType::Timestamp => "timestamp",
+                CastTargetType::DateTime => "datetime",
+            };
+            Err(CccError::type_check(format!(
+                "cannot cast {operand_type} to {target_name}"
+            )))
+        }
+    }
 }
 
 /// Determine the result type of a binary operation, or error if unsupported.
@@ -212,26 +238,6 @@ fn infer_function_return_type(
             Ok(StaticType::Timestamp)
         }
 
-        // Conversion functions
-        "datetime_to_timestamp" => {
-            check_arg_count(name, arg_types, 1)?;
-            require_type(name, &arg_types[0], &StaticType::DateTime)?;
-            Ok(StaticType::Timestamp)
-        }
-        "timestamp_to_datetime" => {
-            if arg_types.is_empty() || arg_types.len() > 2 {
-                return Err(CccError::type_check(format!(
-                    "timestamp_to_datetime expects 1-2 arguments, got {}",
-                    arg_types.len()
-                )));
-            }
-            require_type(name, &arg_types[0], &StaticType::Timestamp)?;
-            if arg_types.len() == 2 {
-                require_type_at(name, &arg_types[1], &StaticType::Integer, 1)?;
-            }
-            Ok(StaticType::DateTime)
-        }
-
         // Time utility functions (zero arguments)
         "now" | "today" => {
             check_arg_count(name, arg_types, 0)?;
@@ -271,16 +277,6 @@ fn require_list(name: &str, actual: &StaticType) -> Result<(), CccError> {
         _ => Err(CccError::type_check(format!(
             "{name}: expected list, got {actual}"
         ))),
-    }
-}
-
-fn require_type(name: &str, actual: &StaticType, expected: &StaticType) -> Result<(), CccError> {
-    if actual == expected || *actual == StaticType::Unknown {
-        Ok(())
-    } else {
-        Err(CccError::type_check(format!(
-            "{name}: expected {expected}, got {actual}"
-        )))
     }
 }
 

--- a/ccc/infrastructure/src/type_checker/ast_type_checker_test.rs
+++ b/ccc/infrastructure/src/type_checker/ast_type_checker_test.rs
@@ -616,11 +616,10 @@ mod tests {
     }
 
     #[test]
-    fn datetime_to_timestamp_with_datetime_passes() {
+    fn cast_datetime_to_timestamp_passes() {
         // Arrange
-        let expr = Expression::FunctionCall {
-            name: "datetime_to_timestamp".to_string(),
-            arguments: vec![Expression::DateTime {
+        let expr = Expression::TypeCast {
+            operand: Box::new(Expression::DateTime {
                 year: 2026,
                 month: 1,
                 day: 1,
@@ -628,7 +627,8 @@ mod tests {
                 minute: 0,
                 second: 0,
                 offset_seconds: 0,
-            }],
+            }),
+            target_type: CastTargetType::Timestamp,
         };
 
         // Act & Assert
@@ -636,11 +636,38 @@ mod tests {
     }
 
     #[test]
-    fn datetime_to_timestamp_with_integer_is_error() {
+    fn cast_timestamp_to_datetime_passes() {
         // Arrange
-        let expr = Expression::FunctionCall {
-            name: "datetime_to_timestamp".to_string(),
-            arguments: vec![Expression::Integer(42)],
+        let expr = Expression::TypeCast {
+            operand: Box::new(Expression::FunctionCall {
+                name: "Timestamp".to_string(),
+                arguments: vec![Expression::Integer(0)],
+            }),
+            target_type: CastTargetType::DateTime,
+        };
+
+        // Act & Assert
+        assert!(check(expr).is_ok());
+    }
+
+    #[test]
+    fn cast_integer_to_timestamp_is_error() {
+        // Arrange
+        let expr = Expression::TypeCast {
+            operand: Box::new(Expression::Integer(42)),
+            target_type: CastTargetType::Timestamp,
+        };
+
+        // Act & Assert
+        assert!(check(expr).is_err());
+    }
+
+    #[test]
+    fn cast_integer_to_datetime_is_error() {
+        // Arrange
+        let expr = Expression::TypeCast {
+            operand: Box::new(Expression::Integer(42)),
+            target_type: CastTargetType::DateTime,
         };
 
         // Act & Assert

--- a/ccc/presentation/tests/cli_test.rs
+++ b/ccc/presentation/tests/cli_test.rs
@@ -936,41 +936,41 @@ fn evaluate_timestamp_float() {
 }
 
 #[test]
-fn evaluate_timestamp_to_datetime() {
+fn evaluate_timestamp_as_datetime() {
     // Arrange
     let mut cmd = ccc();
 
     // Act
-    let result = cmd.arg("timestamp_to_datetime(Timestamp(0))").assert();
+    let result = cmd.arg("Timestamp(0) as datetime").assert();
 
     // Assert
     result.success().stdout("1970-01-01T00:00:00Z\n");
 }
 
 #[test]
-fn evaluate_timestamp_to_datetime_with_offset() {
+fn evaluate_datetime_as_timestamp() {
     // Arrange
     let mut cmd = ccc();
 
     // Act
-    let result = cmd.arg("timestamp_to_datetime(Timestamp(0), 9)").assert();
-
-    // Assert
-    result.success().stdout("1970-01-01T09:00:00+09:00\n");
-}
-
-#[test]
-fn evaluate_datetime_to_timestamp() {
-    // Arrange
-    let mut cmd = ccc();
-
-    // Act
-    let result = cmd
-        .arg("datetime_to_timestamp(2026-01-01T00:00:00Z)")
-        .assert();
+    let result = cmd.arg("2026-01-01T00:00:00Z as timestamp").assert();
 
     // Assert
     result.success().stdout("1767225600\n");
+}
+
+#[test]
+fn evaluate_integer_as_timestamp_fails() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("1 as timestamp").assert();
+
+    // Assert
+    result
+        .failure()
+        .stderr(predicate::str::contains("cannot cast"));
 }
 
 // --- Time arithmetic ---

--- a/docs/example.md
+++ b/docs/example.md
@@ -133,17 +133,20 @@ ccc "2025-12-25T15:30:00+09:00"
 # 2025-12-25T15:30:00+09:00
 ```
 
-## Timestamp Operations
+## Type Cast (`as`)
 
 ```bash
-ccc "datetime_to_timestamp(2025-12-25T00:00:00Z)"
+ccc "3 as float"
+# 3
+
+ccc "3.7 as int"
+# 3
+
+ccc "2025-12-25T00:00:00Z as timestamp"
 # 1766620800
 
-ccc "timestamp_to_datetime(Timestamp(1766620800))"
+ccc "Timestamp(1766620800) as datetime"
 # 2025-12-25T00:00:00Z
-
-ccc "timestamp_to_datetime(Timestamp(1766620800), 9)"
-# 2025-12-25T09:00:00+09:00
 ```
 
 ## Time Utility Functions

--- a/docs/spec/interpreter.md
+++ b/docs/spec/interpreter.md
@@ -109,13 +109,14 @@ All accept a numeric argument (Integer or Float) and return Float.
 | `DateTime(y, mo, d, h, mi, s)` | 6 Integers | DateTime in UTC |
 | `Timestamp(n)` | 1 numeric | Unix timestamp |
 
-### Time Converters
+### Type Cast (`as`)
 
-| Function | Arguments | Description |
-|----------|-----------|-------------|
-| `datetime_to_timestamp(dt)` | DateTime | Convert to Unix timestamp |
-| `timestamp_to_datetime(ts)` | Timestamp | Convert to DateTime (UTC) |
-| `timestamp_to_datetime(ts, offset)` | Timestamp, Integer | Convert with timezone offset (hours) |
+| Expression | Description |
+|-----------|-------------|
+| `n as float` | Integer to float |
+| `n as int` | Float to integer (truncate toward zero) |
+| `dt as timestamp` | DateTime to Unix timestamp |
+| `ts as datetime` | Timestamp to UTC DateTime |
 
 ### Time Utilities
 

--- a/docs/spec/type_checker.md
+++ b/docs/spec/type_checker.md
@@ -93,18 +93,19 @@ Nested expressions in arguments are also type-checked.
 - Exactly 1 argument
 - Argument must be numeric
 
-### Time Converters
+### Type Cast (`as`)
 
-`datetime_to_timestamp`:
+The `as` operator validates the following conversions:
 
-- Exactly 1 argument
-- Argument must be DateTime
+- Integer/Float → `int` or `float` (numeric casts)
+- DateTime → `timestamp`
+- Timestamp → `datetime`
 
-`timestamp_to_datetime`:
+Other combinations produce a type error:
 
-- 1 or 2 arguments
-- First argument must be Timestamp
-- Second argument (optional) must be Integer
+```
+1 as timestamp   → error: cannot cast integer to timestamp
+```
 
 ### Time Utilities
 

--- a/docs/spec/type_system.md
+++ b/docs/spec/type_system.md
@@ -164,13 +164,18 @@ All require a numeric argument (Integer or Float) and return Float.
 | `DateTime` | 6 Integers (year, month, day, hour, minute, second) | DateTime |
 | `Timestamp` | 1 numeric | Timestamp |
 
-### Time Converters
+### Type Cast (`as`)
 
-| Function | Arguments | Output |
-|----------|-----------|--------|
-| `datetime_to_timestamp` | DateTime | Timestamp |
-| `timestamp_to_datetime` | Timestamp | DateTime |
-| `timestamp_to_datetime` | Timestamp, Integer (offset hours) | DateTime |
+The `as` operator performs explicit type conversions:
+
+| Source | Target | Behavior |
+|--------|--------|----------|
+| Integer | Float | Widen to float |
+| Float | Integer | Truncate toward zero |
+| DateTime | Timestamp | Convert to epoch seconds |
+| Timestamp | DateTime | Convert to UTC datetime |
+
+Other combinations (e.g., `int as timestamp`, `duration as int`) produce a type error.
 
 ### Time Utilities
 


### PR DESCRIPTION
## Summary

- `as timestamp` / `as datetime` キャストを追加し、`datetime_to_timestamp` / `timestamp_to_datetime` 関数を削除
- 型チェッカーに `infer_cast_type` を導入し、全キャストルール（int/float/datetime/timestamp）を一箇所に集約
- ドキュメント（type_system, type_checker, interpreter, example）を更新

## Test plan

- [x] 型チェッカーテスト: `datetime as timestamp`, `timestamp as datetime` の許可、`int as timestamp` 等の拒否
- [x] 評価器テスト: datetime→timestamp 変換、timestamp→datetime 変換、ラウンドトリップ
- [x] 統合テスト: `2026-01-01T00:00:00Z as timestamp`, `Timestamp(0) as datetime`, `1 as timestamp`（エラー）
- [x] 旧関数 `datetime_to_timestamp` / `timestamp_to_datetime` が `undefined function` エラーになることを確認

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)