### PR TITLE
Support consecutive unary operators (--2000)

### DIFF
--- a/ccc/infrastructure/src/parser/grammar.pest
+++ b/ccc/infrastructure/src/parser/grammar.pest
@@ -4,7 +4,7 @@ term = { power ~ (multiplicative_operator ~ power)* }
 
 power = { unary ~ (power_operator ~ unary)* }
 
-unary = { unary_operator? ~ postfix }
+unary = { unary_operator* ~ postfix }
 
 postfix = { atom ~ postfix_suffix* }
 

--- a/ccc/infrastructure/src/parser/pest_based_parser.rs
+++ b/ccc/infrastructure/src/parser/pest_based_parser.rs
@@ -120,26 +120,36 @@ impl PestBasedParser {
 
     fn build_unary(pair: pest::iterators::Pair<Rule>) -> Result<Expression, CccError> {
         let mut inner = pair.into_inner();
-        let first = inner
+
+        // Collect unary operators (zero or more)
+        let mut operators = Vec::new();
+        while let Some(pair) = inner.peek() {
+            if pair.as_rule() == Rule::unary_operator {
+                let op_pair = inner.next().unwrap();
+                let operator = match op_pair.as_str() {
+                    "-" => UnaryOperation::Negate,
+                    _ => UnaryOperation::Positive,
+                };
+                operators.push(operator);
+            } else {
+                break;
+            }
+        }
+
+        let operand_pair = inner
             .next()
             .ok_or_else(|| CccError::parse("expected expression".to_string()))?;
+        let mut result = Self::build_expression(operand_pair)?;
 
-        if first.as_rule() == Rule::unary_operator {
-            let operand_pair = inner.next().ok_or_else(|| {
-                CccError::parse("expected operand after unary operator".to_string())
-            })?;
-            let operator = match first.as_str() {
-                "-" => UnaryOperation::Negate,
-                _ => UnaryOperation::Positive,
-            };
-            let operand = Self::build_expression(operand_pair)?;
-            Ok(Expression::UnaryOperation {
+        // Wrap from innermost to outermost
+        for operator in operators.into_iter().rev() {
+            result = Expression::UnaryOperation {
                 operator,
-                operand: Box::new(operand),
-            })
-        } else {
-            Self::build_expression(first)
+                operand: Box::new(result),
+            };
         }
+
+        Ok(result)
     }
 
     fn build_postfix(pair: pest::iterators::Pair<Rule>) -> Result<Expression, CccError> {

--- a/ccc/infrastructure/src/parser/pest_based_parser_test.rs
+++ b/ccc/infrastructure/src/parser/pest_based_parser_test.rs
@@ -346,6 +346,47 @@ mod tests {
         assert_eq!(result, expected);
     }
 
+    #[test]
+    fn parse_double_negate() {
+        // Arrange: --2000 → UnaryOperation(-, UnaryOperation(-, 2000))
+        let input = "- -2000";
+        let expected = Expression::UnaryOperation {
+            operator: UnaryOperation::Negate,
+            operand: Box::new(Expression::UnaryOperation {
+                operator: UnaryOperation::Negate,
+                operand: Box::new(Expression::Integer(2000)),
+            }),
+        };
+
+        // Act
+        let result = parse_expr(input);
+
+        // Assert
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_triple_negate() {
+        // Arrange: - - -3 → Negate(Negate(Negate(3)))
+        let input = "- - -3";
+        let expected = Expression::UnaryOperation {
+            operator: UnaryOperation::Negate,
+            operand: Box::new(Expression::UnaryOperation {
+                operator: UnaryOperation::Negate,
+                operand: Box::new(Expression::UnaryOperation {
+                    operator: UnaryOperation::Negate,
+                    operand: Box::new(Expression::Integer(3)),
+                }),
+            }),
+        };
+
+        // Act
+        let result = parse_expr(input);
+
+        // Assert
+        assert_eq!(result, expected);
+    }
+
     // --- Parentheses ---
 
     #[test]

--- a/ccc/presentation/tests/cli_test.rs
+++ b/ccc/presentation/tests/cli_test.rs
@@ -127,6 +127,54 @@ fn evaluate_negative_unary() {
     result.success().stdout("-2\n");
 }
 
+#[test]
+fn evaluate_double_negate() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.args(["--", "- -2000"]).assert();
+
+    // Assert
+    result.success().stdout("2000\n");
+}
+
+#[test]
+fn evaluate_triple_negate() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.args(["--", "- - -3"]).assert();
+
+    // Assert
+    result.success().stdout("-3\n");
+}
+
+#[test]
+fn evaluate_double_negate_in_expression() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.args(["--", "5 + - -3"]).assert();
+
+    // Assert
+    result.success().stdout("8\n");
+}
+
+#[test]
+fn evaluate_double_negate_float() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.args(["--", "- -1.5"]).assert();
+
+    // Assert
+    result.success().stdout("1.5\n");
+}
+
 // --- Space-separated expression ---
 
 #[test]


### PR DESCRIPTION
## Summary

- grammar.pest の `unary` ルールを `unary_operator?` から `unary_operator*` に変更し、連続する単項演算子を許可
- パーサーで複数の単項演算子をネストした `UnaryOperation` ノードとして構築

## Test plan

- [x] パーサーテスト: `- -2000` (二重否定), `- - -3` (三重否定) のAST構築
- [x] 統合テスト: `- -2000` → `2000`, `- - -3` → `-3`, `5 + - -3` → `8`, `- -1.5` → `1.5`

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)