### PR TITLE
Add ccc show builtin command

### DIFF
--- a/ccc/presentation/src/cli.rs
+++ b/ccc/presentation/src/cli.rs
@@ -15,4 +15,15 @@ pub struct Cli {
 pub enum Command {
     /// Start interactive REPL
     Repl,
+    /// Show information
+    Show {
+        #[command(subcommand)]
+        target: ShowTarget,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum ShowTarget {
+    /// List all built-in functions
+    Builtin,
 }

--- a/ccc/presentation/src/input_mode.rs
+++ b/ccc/presentation/src/input_mode.rs
@@ -1,11 +1,13 @@
 use std::io::{self, IsTerminal};
 
-use crate::cli::{Cli, Command};
+use crate::cli::{Cli, Command, ShowTarget};
 
 /// Determines how the application should process input.
 pub enum InputMode {
     /// Interactive REPL session
     Repl,
+    /// Show built-in function list
+    ShowBuiltin,
     /// Evaluate a single expression from CLI arguments
     Expression(String),
     /// Read expressions from piped stdin, one per line
@@ -17,8 +19,12 @@ pub enum InputMode {
 }
 
 pub fn resolve_input_mode(cli: &Cli) -> InputMode {
-    if let Some(Command::Repl) = &cli.command {
-        return InputMode::Repl;
+    match &cli.command {
+        Some(Command::Repl) => return InputMode::Repl,
+        Some(Command::Show { target }) => match target {
+            ShowTarget::Builtin => return InputMode::ShowBuiltin,
+        },
+        None => {}
     }
 
     let has_args = !cli.expression.is_empty();

--- a/ccc/presentation/src/main.rs
+++ b/ccc/presentation/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod input_mode;
+mod show_builtin;
 
 use std::io;
 
@@ -25,6 +26,9 @@ fn main() {
     let calculate = CalculateMathExpressionUsecase::new(parser, type_checker, evaluator);
 
     match mode {
+        InputMode::ShowBuiltin => {
+            show_builtin::print_builtin_list();
+        }
         InputMode::Repl => {
             let repl = InteractiveReplUsecase::new(calculate);
             if let Err(e) = repl.run() {

--- a/ccc/presentation/src/show_builtin.rs
+++ b/ccc/presentation/src/show_builtin.rs
@@ -1,0 +1,55 @@
+/// Print the built-in function reference to stdout.
+pub fn print_builtin_list() {
+    print!(
+        "\
+Built-in Functions:
+
+  Math
+    sqrt(x)          Square root
+    abs(x)           Absolute value
+    sin(x)           Sine
+    cos(x)           Cosine
+    tan(x)           Tangent
+    arcsin(x)        Arcsine
+    arccos(x)        Arccosine
+    arctan(x)        Arctangent
+    log(x)           Natural logarithm
+    log2(x)          Base-2 logarithm
+    log10(x)         Base-10 logarithm
+    floor(x)         Floor
+    ceil(x)          Ceiling
+    round(x)         Round
+
+  Statistics
+    mean(l)          Mean of elements
+    var(l)           Variance of elements
+    max(l)           Maximum element
+    min(l)           Minimum element
+    median(l)        Median of elements
+
+  List
+    len(l)           Length of list
+    sum(l)           Sum of elements
+    prod(l)          Product of elements
+    head(l)          First element
+    tail(l)          All elements except first
+
+  Constructor
+    DurationTime(h, m, s)           Create duration
+    DurationTime(d, h, m, s)        Create duration with days
+    DateTime(y, mo, d, h, mi, s)    Create datetime (UTC)
+    Timestamp(n)                    Create timestamp
+
+  Type Cast (as)
+    <expr> as int                   Convert to integer (truncate)
+    <expr> as float                 Convert to float
+    <expr> as timestamp             DateTime to timestamp
+    <expr> as datetime              Timestamp to datetime (UTC)
+
+  Current Time
+    now()                 Current datetime (UTC)
+    today()               Today at 00:00:00 (UTC)
+    current_timestamp()   Current unix timestamp
+"
+    );
+}

--- a/ccc/presentation/src/show_builtin.rs
+++ b/ccc/presentation/src/show_builtin.rs
@@ -1,55 +1,207 @@
+/// A single entry in the built-in reference.
+struct BuiltinEntry {
+    signature: &'static str,
+    description: &'static str,
+}
+
+/// A named group of related built-in entries.
+struct BuiltinCategory {
+    name: &'static str,
+    entries: &'static [BuiltinEntry],
+}
+
+const BUILTIN_CATEGORIES: &[BuiltinCategory] = &[
+    BuiltinCategory {
+        name: "Math",
+        entries: &[
+            BuiltinEntry {
+                signature: "sqrt(x)",
+                description: "Square root",
+            },
+            BuiltinEntry {
+                signature: "abs(x)",
+                description: "Absolute value",
+            },
+            BuiltinEntry {
+                signature: "sin(x)",
+                description: "Sine",
+            },
+            BuiltinEntry {
+                signature: "cos(x)",
+                description: "Cosine",
+            },
+            BuiltinEntry {
+                signature: "tan(x)",
+                description: "Tangent",
+            },
+            BuiltinEntry {
+                signature: "arcsin(x)",
+                description: "Arcsine",
+            },
+            BuiltinEntry {
+                signature: "arccos(x)",
+                description: "Arccosine",
+            },
+            BuiltinEntry {
+                signature: "arctan(x)",
+                description: "Arctangent",
+            },
+            BuiltinEntry {
+                signature: "log(x)",
+                description: "Natural logarithm",
+            },
+            BuiltinEntry {
+                signature: "log2(x)",
+                description: "Base-2 logarithm",
+            },
+            BuiltinEntry {
+                signature: "log10(x)",
+                description: "Base-10 logarithm",
+            },
+            BuiltinEntry {
+                signature: "floor(x)",
+                description: "Floor",
+            },
+            BuiltinEntry {
+                signature: "ceil(x)",
+                description: "Ceiling",
+            },
+            BuiltinEntry {
+                signature: "round(x)",
+                description: "Round",
+            },
+        ],
+    },
+    BuiltinCategory {
+        name: "Statistics",
+        entries: &[
+            BuiltinEntry {
+                signature: "mean(l)",
+                description: "Mean of elements",
+            },
+            BuiltinEntry {
+                signature: "var(l)",
+                description: "Variance of elements",
+            },
+            BuiltinEntry {
+                signature: "max(l)",
+                description: "Maximum element",
+            },
+            BuiltinEntry {
+                signature: "min(l)",
+                description: "Minimum element",
+            },
+            BuiltinEntry {
+                signature: "median(l)",
+                description: "Median of elements",
+            },
+        ],
+    },
+    BuiltinCategory {
+        name: "List",
+        entries: &[
+            BuiltinEntry {
+                signature: "len(l)",
+                description: "Length of list",
+            },
+            BuiltinEntry {
+                signature: "sum(l)",
+                description: "Sum of elements",
+            },
+            BuiltinEntry {
+                signature: "prod(l)",
+                description: "Product of elements",
+            },
+            BuiltinEntry {
+                signature: "head(l)",
+                description: "First element",
+            },
+            BuiltinEntry {
+                signature: "tail(l)",
+                description: "All elements except first",
+            },
+        ],
+    },
+    BuiltinCategory {
+        name: "Constructor",
+        entries: &[
+            BuiltinEntry {
+                signature: "DurationTime(h, m, s)",
+                description: "Create duration",
+            },
+            BuiltinEntry {
+                signature: "DurationTime(d, h, m, s)",
+                description: "Create duration with days",
+            },
+            BuiltinEntry {
+                signature: "DateTime(y, mo, d, h, mi, s)",
+                description: "Create datetime (UTC)",
+            },
+            BuiltinEntry {
+                signature: "Timestamp(n)",
+                description: "Create timestamp",
+            },
+        ],
+    },
+    BuiltinCategory {
+        name: "Type Cast (as)",
+        entries: &[
+            BuiltinEntry {
+                signature: "<expr> as int",
+                description: "Convert to integer (truncate)",
+            },
+            BuiltinEntry {
+                signature: "<expr> as float",
+                description: "Convert to float",
+            },
+            BuiltinEntry {
+                signature: "<expr> as timestamp",
+                description: "DateTime to timestamp",
+            },
+            BuiltinEntry {
+                signature: "<expr> as datetime",
+                description: "Timestamp to datetime (UTC)",
+            },
+        ],
+    },
+    BuiltinCategory {
+        name: "Current Time",
+        entries: &[
+            BuiltinEntry {
+                signature: "now()",
+                description: "Current datetime (UTC)",
+            },
+            BuiltinEntry {
+                signature: "today()",
+                description: "Today at 00:00:00 (UTC)",
+            },
+            BuiltinEntry {
+                signature: "current_timestamp()",
+                description: "Current unix timestamp",
+            },
+        ],
+    },
+];
+
+/// Column width for aligning signatures and descriptions.
+const SIGNATURE_COLUMN_WIDTH: usize = 32;
+
 /// Print the built-in function reference to stdout.
 pub fn print_builtin_list() {
-    print!(
-        "\
-Built-in Functions:
+    println!("Built-in Functions:");
 
-  Math
-    sqrt(x)          Square root
-    abs(x)           Absolute value
-    sin(x)           Sine
-    cos(x)           Cosine
-    tan(x)           Tangent
-    arcsin(x)        Arcsine
-    arccos(x)        Arccosine
-    arctan(x)        Arctangent
-    log(x)           Natural logarithm
-    log2(x)          Base-2 logarithm
-    log10(x)         Base-10 logarithm
-    floor(x)         Floor
-    ceil(x)          Ceiling
-    round(x)         Round
-
-  Statistics
-    mean(l)          Mean of elements
-    var(l)           Variance of elements
-    max(l)           Maximum element
-    min(l)           Minimum element
-    median(l)        Median of elements
-
-  List
-    len(l)           Length of list
-    sum(l)           Sum of elements
-    prod(l)          Product of elements
-    head(l)          First element
-    tail(l)          All elements except first
-
-  Constructor
-    DurationTime(h, m, s)           Create duration
-    DurationTime(d, h, m, s)        Create duration with days
-    DateTime(y, mo, d, h, mi, s)    Create datetime (UTC)
-    Timestamp(n)                    Create timestamp
-
-  Type Cast (as)
-    <expr> as int                   Convert to integer (truncate)
-    <expr> as float                 Convert to float
-    <expr> as timestamp             DateTime to timestamp
-    <expr> as datetime              Timestamp to datetime (UTC)
-
-  Current Time
-    now()                 Current datetime (UTC)
-    today()               Today at 00:00:00 (UTC)
-    current_timestamp()   Current unix timestamp
-"
-    );
+    for category in BUILTIN_CATEGORIES {
+        println!();
+        println!("  {}", category.name);
+        for entry in category.entries {
+            let padding = SIGNATURE_COLUMN_WIDTH.saturating_sub(entry.signature.len());
+            println!(
+                "    {}{:width$}{}",
+                entry.signature,
+                "",
+                entry.description,
+                width = padding
+            );
+        }
+    }
 }

--- a/ccc/presentation/src/show_builtin.rs
+++ b/ccc/presentation/src/show_builtin.rs
@@ -1,6 +1,7 @@
 /// A single entry in the built-in reference.
 struct BuiltinEntry {
     signature: &'static str,
+    return_type: &'static str,
     description: &'static str,
 }
 
@@ -15,59 +16,73 @@ const BUILTIN_CATEGORIES: &[BuiltinCategory] = &[
         name: "Math",
         entries: &[
             BuiltinEntry {
-                signature: "sqrt(x)",
+                signature: "sqrt(x: number)",
+                return_type: "float",
                 description: "Square root",
             },
             BuiltinEntry {
-                signature: "abs(x)",
+                signature: "abs(x: number)",
+                return_type: "same as input",
                 description: "Absolute value",
             },
             BuiltinEntry {
-                signature: "sin(x)",
+                signature: "sin(x: number)",
+                return_type: "float",
                 description: "Sine",
             },
             BuiltinEntry {
-                signature: "cos(x)",
+                signature: "cos(x: number)",
+                return_type: "float",
                 description: "Cosine",
             },
             BuiltinEntry {
-                signature: "tan(x)",
+                signature: "tan(x: number)",
+                return_type: "float",
                 description: "Tangent",
             },
             BuiltinEntry {
-                signature: "arcsin(x)",
+                signature: "arcsin(x: number)",
+                return_type: "float",
                 description: "Arcsine",
             },
             BuiltinEntry {
-                signature: "arccos(x)",
+                signature: "arccos(x: number)",
+                return_type: "float",
                 description: "Arccosine",
             },
             BuiltinEntry {
-                signature: "arctan(x)",
+                signature: "arctan(x: number)",
+                return_type: "float",
                 description: "Arctangent",
             },
             BuiltinEntry {
-                signature: "log(x)",
+                signature: "log(x: number)",
+                return_type: "float",
                 description: "Natural logarithm",
             },
             BuiltinEntry {
-                signature: "log2(x)",
+                signature: "log2(x: number)",
+                return_type: "float",
                 description: "Base-2 logarithm",
             },
             BuiltinEntry {
-                signature: "log10(x)",
+                signature: "log10(x: number)",
+                return_type: "float",
                 description: "Base-10 logarithm",
             },
             BuiltinEntry {
-                signature: "floor(x)",
+                signature: "floor(x: number)",
+                return_type: "float",
                 description: "Floor",
             },
             BuiltinEntry {
-                signature: "ceil(x)",
+                signature: "ceil(x: number)",
+                return_type: "float",
                 description: "Ceiling",
             },
             BuiltinEntry {
-                signature: "round(x)",
+                signature: "round(x: number)",
+                return_type: "float",
                 description: "Round",
             },
         ],
@@ -76,23 +91,28 @@ const BUILTIN_CATEGORIES: &[BuiltinCategory] = &[
         name: "Statistics",
         entries: &[
             BuiltinEntry {
-                signature: "mean(l)",
+                signature: "mean(l: list)",
+                return_type: "float | duration",
                 description: "Mean of elements",
             },
             BuiltinEntry {
-                signature: "var(l)",
+                signature: "var(l: list)",
+                return_type: "float",
                 description: "Variance of elements",
             },
             BuiltinEntry {
-                signature: "max(l)",
+                signature: "max(l: list)",
+                return_type: "same as element",
                 description: "Maximum element",
             },
             BuiltinEntry {
-                signature: "min(l)",
+                signature: "min(l: list)",
+                return_type: "same as element",
                 description: "Minimum element",
             },
             BuiltinEntry {
-                signature: "median(l)",
+                signature: "median(l: list)",
+                return_type: "float | duration",
                 description: "Median of elements",
             },
         ],
@@ -101,23 +121,28 @@ const BUILTIN_CATEGORIES: &[BuiltinCategory] = &[
         name: "List",
         entries: &[
             BuiltinEntry {
-                signature: "len(l)",
+                signature: "len(l: list)",
+                return_type: "int",
                 description: "Length of list",
             },
             BuiltinEntry {
-                signature: "sum(l)",
+                signature: "sum(l: list)",
+                return_type: "number | duration",
                 description: "Sum of elements",
             },
             BuiltinEntry {
-                signature: "prod(l)",
+                signature: "prod(l: list)",
+                return_type: "number",
                 description: "Product of elements",
             },
             BuiltinEntry {
-                signature: "head(l)",
+                signature: "head(l: list)",
+                return_type: "element type",
                 description: "First element",
             },
             BuiltinEntry {
-                signature: "tail(l)",
+                signature: "tail(l: list)",
+                return_type: "list",
                 description: "All elements except first",
             },
         ],
@@ -126,19 +151,23 @@ const BUILTIN_CATEGORIES: &[BuiltinCategory] = &[
         name: "Constructor",
         entries: &[
             BuiltinEntry {
-                signature: "DurationTime(h, m, s)",
+                signature: "DurationTime(h, m, s: int)",
+                return_type: "duration",
                 description: "Create duration",
             },
             BuiltinEntry {
-                signature: "DurationTime(d, h, m, s)",
+                signature: "DurationTime(d, h, m, s: int)",
+                return_type: "duration",
                 description: "Create duration with days",
             },
             BuiltinEntry {
-                signature: "DateTime(y, mo, d, h, mi, s)",
+                signature: "DateTime(y, mo, d, h, mi, s: int)",
+                return_type: "datetime",
                 description: "Create datetime (UTC)",
             },
             BuiltinEntry {
-                signature: "Timestamp(n)",
+                signature: "Timestamp(n: number)",
+                return_type: "timestamp",
                 description: "Create timestamp",
             },
         ],
@@ -147,19 +176,23 @@ const BUILTIN_CATEGORIES: &[BuiltinCategory] = &[
         name: "Type Cast (as)",
         entries: &[
             BuiltinEntry {
-                signature: "<expr> as int",
+                signature: "<number> as int",
+                return_type: "int",
                 description: "Convert to integer (truncate)",
             },
             BuiltinEntry {
-                signature: "<expr> as float",
+                signature: "<number> as float",
+                return_type: "float",
                 description: "Convert to float",
             },
             BuiltinEntry {
-                signature: "<expr> as timestamp",
+                signature: "<datetime> as timestamp",
+                return_type: "timestamp",
                 description: "DateTime to timestamp",
             },
             BuiltinEntry {
-                signature: "<expr> as datetime",
+                signature: "<timestamp> as datetime",
+                return_type: "datetime",
                 description: "Timestamp to datetime (UTC)",
             },
         ],
@@ -169,22 +202,26 @@ const BUILTIN_CATEGORIES: &[BuiltinCategory] = &[
         entries: &[
             BuiltinEntry {
                 signature: "now()",
+                return_type: "datetime",
                 description: "Current datetime (UTC)",
             },
             BuiltinEntry {
                 signature: "today()",
+                return_type: "datetime",
                 description: "Today at 00:00:00 (UTC)",
             },
             BuiltinEntry {
                 signature: "current_timestamp()",
+                return_type: "timestamp",
                 description: "Current unix timestamp",
             },
         ],
     },
 ];
 
-/// Column width for aligning signatures and descriptions.
-const SIGNATURE_COLUMN_WIDTH: usize = 32;
+/// Column width for aligning each column.
+const SIGNATURE_COLUMN_WIDTH: usize = 38;
+const RETURN_TYPE_COLUMN_WIDTH: usize = 18;
 
 /// Print the built-in function reference to stdout.
 pub fn print_builtin_list() {
@@ -194,13 +231,17 @@ pub fn print_builtin_list() {
         println!();
         println!("  {}", category.name);
         for entry in category.entries {
-            let padding = SIGNATURE_COLUMN_WIDTH.saturating_sub(entry.signature.len());
+            let sig_pad = SIGNATURE_COLUMN_WIDTH.saturating_sub(entry.signature.len());
+            let ret_pad = RETURN_TYPE_COLUMN_WIDTH.saturating_sub(entry.return_type.len());
             println!(
-                "    {}{:width$}{}",
+                "    {}{:sw$}-> {}{:rw$}{}",
                 entry.signature,
                 "",
+                entry.return_type,
+                "",
                 entry.description,
-                width = padding
+                sw = sig_pad,
+                rw = ret_pad,
             );
         }
     }

--- a/ccc/presentation/src/show_builtin.rs
+++ b/ccc/presentation/src/show_builtin.rs
@@ -1,7 +1,6 @@
 /// A single entry in the built-in reference.
 struct BuiltinEntry {
     signature: &'static str,
-    return_type: &'static str,
     description: &'static str,
 }
 
@@ -16,73 +15,59 @@ const BUILTIN_CATEGORIES: &[BuiltinCategory] = &[
         name: "Math",
         entries: &[
             BuiltinEntry {
-                signature: "sqrt(x: number)",
-                return_type: "float",
+                signature: "sqrt(x: int | float) -> float",
                 description: "Square root",
             },
             BuiltinEntry {
-                signature: "abs(x: number)",
-                return_type: "same as input",
-                description: "Absolute value",
+                signature: "abs(x: int | float) -> int | float",
+                description: "Absolute value (preserves input type)",
             },
             BuiltinEntry {
-                signature: "sin(x: number)",
-                return_type: "float",
+                signature: "sin(x: int | float) -> float",
                 description: "Sine",
             },
             BuiltinEntry {
-                signature: "cos(x: number)",
-                return_type: "float",
+                signature: "cos(x: int | float) -> float",
                 description: "Cosine",
             },
             BuiltinEntry {
-                signature: "tan(x: number)",
-                return_type: "float",
+                signature: "tan(x: int | float) -> float",
                 description: "Tangent",
             },
             BuiltinEntry {
-                signature: "arcsin(x: number)",
-                return_type: "float",
+                signature: "arcsin(x: int | float) -> float",
                 description: "Arcsine",
             },
             BuiltinEntry {
-                signature: "arccos(x: number)",
-                return_type: "float",
+                signature: "arccos(x: int | float) -> float",
                 description: "Arccosine",
             },
             BuiltinEntry {
-                signature: "arctan(x: number)",
-                return_type: "float",
+                signature: "arctan(x: int | float) -> float",
                 description: "Arctangent",
             },
             BuiltinEntry {
-                signature: "log(x: number)",
-                return_type: "float",
+                signature: "log(x: int | float) -> float",
                 description: "Natural logarithm",
             },
             BuiltinEntry {
-                signature: "log2(x: number)",
-                return_type: "float",
+                signature: "log2(x: int | float) -> float",
                 description: "Base-2 logarithm",
             },
             BuiltinEntry {
-                signature: "log10(x: number)",
-                return_type: "float",
+                signature: "log10(x: int | float) -> float",
                 description: "Base-10 logarithm",
             },
             BuiltinEntry {
-                signature: "floor(x: number)",
-                return_type: "float",
+                signature: "floor(x: int | float) -> float",
                 description: "Floor",
             },
             BuiltinEntry {
-                signature: "ceil(x: number)",
-                return_type: "float",
+                signature: "ceil(x: int | float) -> float",
                 description: "Ceiling",
             },
             BuiltinEntry {
-                signature: "round(x: number)",
-                return_type: "float",
+                signature: "round(x: int | float) -> float",
                 description: "Round",
             },
         ],
@@ -91,29 +76,32 @@ const BUILTIN_CATEGORIES: &[BuiltinCategory] = &[
         name: "Statistics",
         entries: &[
             BuiltinEntry {
-                signature: "mean(l: list)",
-                return_type: "float | duration",
-                description: "Mean of elements",
+                signature: "mean(l: list[int | float]) -> float",
+                description: "Mean of numeric elements",
             },
             BuiltinEntry {
-                signature: "var(l: list)",
-                return_type: "float",
-                description: "Variance of elements",
+                signature: "mean(l: list[duration]) -> duration",
+                description: "Mean of duration elements",
             },
             BuiltinEntry {
-                signature: "max(l: list)",
-                return_type: "same as element",
+                signature: "var(l: list[int | float]) -> float",
+                description: "Variance of numeric elements",
+            },
+            BuiltinEntry {
+                signature: "max(l: list[int | float | duration]) -> int | float | duration",
                 description: "Maximum element",
             },
             BuiltinEntry {
-                signature: "min(l: list)",
-                return_type: "same as element",
+                signature: "min(l: list[int | float | duration]) -> int | float | duration",
                 description: "Minimum element",
             },
             BuiltinEntry {
-                signature: "median(l: list)",
-                return_type: "float | duration",
-                description: "Median of elements",
+                signature: "median(l: list[int | float]) -> float",
+                description: "Median of numeric elements",
+            },
+            BuiltinEntry {
+                signature: "median(l: list[duration]) -> duration",
+                description: "Median of duration elements",
             },
         ],
     },
@@ -121,28 +109,27 @@ const BUILTIN_CATEGORIES: &[BuiltinCategory] = &[
         name: "List",
         entries: &[
             BuiltinEntry {
-                signature: "len(l: list)",
-                return_type: "int",
+                signature: "len(l: list) -> int",
                 description: "Length of list",
             },
             BuiltinEntry {
-                signature: "sum(l: list)",
-                return_type: "number | duration",
-                description: "Sum of elements",
+                signature: "sum(l: list[int | float]) -> int | float",
+                description: "Sum of numeric elements",
             },
             BuiltinEntry {
-                signature: "prod(l: list)",
-                return_type: "number",
-                description: "Product of elements",
+                signature: "sum(l: list[duration]) -> duration",
+                description: "Sum of duration elements",
             },
             BuiltinEntry {
-                signature: "head(l: list)",
-                return_type: "element type",
+                signature: "prod(l: list[int | float]) -> int | float",
+                description: "Product of numeric elements",
+            },
+            BuiltinEntry {
+                signature: "head(l: list) -> element type",
                 description: "First element",
             },
             BuiltinEntry {
-                signature: "tail(l: list)",
-                return_type: "list",
+                signature: "tail(l: list) -> list",
                 description: "All elements except first",
             },
         ],
@@ -151,23 +138,19 @@ const BUILTIN_CATEGORIES: &[BuiltinCategory] = &[
         name: "Constructor",
         entries: &[
             BuiltinEntry {
-                signature: "DurationTime(h, m, s: int)",
-                return_type: "duration",
+                signature: "DurationTime(h, m, s: int) -> duration",
                 description: "Create duration",
             },
             BuiltinEntry {
-                signature: "DurationTime(d, h, m, s: int)",
-                return_type: "duration",
+                signature: "DurationTime(d, h, m, s: int) -> duration",
                 description: "Create duration with days",
             },
             BuiltinEntry {
-                signature: "DateTime(y, mo, d, h, mi, s: int)",
-                return_type: "datetime",
+                signature: "DateTime(y, mo, d, h, mi, s: int) -> datetime",
                 description: "Create datetime (UTC)",
             },
             BuiltinEntry {
-                signature: "Timestamp(n: number)",
-                return_type: "timestamp",
+                signature: "Timestamp(n: int | float) -> timestamp",
                 description: "Create timestamp",
             },
         ],
@@ -176,24 +159,20 @@ const BUILTIN_CATEGORIES: &[BuiltinCategory] = &[
         name: "Type Cast (as)",
         entries: &[
             BuiltinEntry {
-                signature: "<number> as int",
-                return_type: "int",
-                description: "Convert to integer (truncate)",
+                signature: "<int | float> as int -> int",
+                description: "Truncate toward zero",
             },
             BuiltinEntry {
-                signature: "<number> as float",
-                return_type: "float",
-                description: "Convert to float",
+                signature: "<int | float> as float -> float",
+                description: "Widen to float",
             },
             BuiltinEntry {
-                signature: "<datetime> as timestamp",
-                return_type: "timestamp",
-                description: "DateTime to timestamp",
+                signature: "<datetime> as timestamp -> timestamp",
+                description: "Convert to epoch seconds",
             },
             BuiltinEntry {
-                signature: "<timestamp> as datetime",
-                return_type: "datetime",
-                description: "Timestamp to datetime (UTC)",
+                signature: "<timestamp> as datetime -> datetime",
+                description: "Convert to UTC datetime",
             },
         ],
     },
@@ -201,27 +180,23 @@ const BUILTIN_CATEGORIES: &[BuiltinCategory] = &[
         name: "Current Time",
         entries: &[
             BuiltinEntry {
-                signature: "now()",
-                return_type: "datetime",
+                signature: "now() -> datetime",
                 description: "Current datetime (UTC)",
             },
             BuiltinEntry {
-                signature: "today()",
-                return_type: "datetime",
+                signature: "today() -> datetime",
                 description: "Today at 00:00:00 (UTC)",
             },
             BuiltinEntry {
-                signature: "current_timestamp()",
-                return_type: "timestamp",
+                signature: "current_timestamp() -> timestamp",
                 description: "Current unix timestamp",
             },
         ],
     },
 ];
 
-/// Column width for aligning each column.
-const SIGNATURE_COLUMN_WIDTH: usize = 38;
-const RETURN_TYPE_COLUMN_WIDTH: usize = 18;
+/// Column width for aligning signatures and descriptions.
+const SIGNATURE_COLUMN_WIDTH: usize = 64;
 
 /// Print the built-in function reference to stdout.
 pub fn print_builtin_list() {
@@ -231,17 +206,13 @@ pub fn print_builtin_list() {
         println!();
         println!("  {}", category.name);
         for entry in category.entries {
-            let sig_pad = SIGNATURE_COLUMN_WIDTH.saturating_sub(entry.signature.len());
-            let ret_pad = RETURN_TYPE_COLUMN_WIDTH.saturating_sub(entry.return_type.len());
+            let padding = SIGNATURE_COLUMN_WIDTH.saturating_sub(entry.signature.len());
             println!(
-                "    {}{:sw$}-> {}{:rw$}{}",
+                "    {}{:w$}{}",
                 entry.signature,
                 "",
-                entry.return_type,
-                "",
                 entry.description,
-                sw = sig_pad,
-                rw = ret_pad,
+                w = padding,
             );
         }
     }

--- a/ccc/presentation/tests/cli_test.rs
+++ b/ccc/presentation/tests/cli_test.rs
@@ -1125,6 +1125,72 @@ fn repl_subcommand_exists() {
     result.success();
 }
 
+// --- Show builtin subcommand ---
+
+#[test]
+fn show_builtin_succeeds() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.args(["show", "builtin"]).assert();
+
+    // Assert
+    result
+        .success()
+        .stdout(predicate::str::contains("Built-in Functions:"));
+}
+
+#[test]
+fn show_builtin_contains_all_function_names() {
+    // Arrange
+    let mut cmd = ccc();
+    let expected_names = [
+        "sqrt",
+        "abs",
+        "sin",
+        "cos",
+        "tan",
+        "arcsin",
+        "arccos",
+        "arctan",
+        "log",
+        "log2",
+        "log10",
+        "floor",
+        "ceil",
+        "round",
+        "mean",
+        "var",
+        "max",
+        "min",
+        "median",
+        "len",
+        "sum",
+        "prod",
+        "head",
+        "tail",
+        "DurationTime",
+        "DateTime",
+        "Timestamp",
+        "now",
+        "today",
+        "current_timestamp",
+    ];
+
+    // Act
+    let output = cmd.args(["show", "builtin"]).output().unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // Assert
+    for name in expected_names {
+        assert!(
+            stdout.contains(name),
+            "expected output to contain '{name}', but it was missing"
+        );
+    }
+}
+
 // --- Method chain ---
 
 #[test]


### PR DESCRIPTION
## Summary

- `ccc show builtin` サブコマンドを追加し、ビルトイン関数・型キャスト・コンストラクタの一覧を表示
- Math / Statistics / List / Constructor / Type Cast / Current Time のカテゴリ別に整理

## Test plan

- [x] `ccc show builtin` が正常終了し `Built-in Functions:` ヘッダーを含む出力を返すこと
- [x] 全30個のビルトイン関数名が出力に含まれていること

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)