### PR TITLE
Define naming convention for built-in functions

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -49,6 +49,8 @@ cargo clippy
 
 ## Adding a New Built-in Function
 
+Function names must follow the [Naming Convention](spec/naming_convention.md). In short: regular functions use **snake_case**, constructors use **PascalCase**.
+
 1. Add the function name to the match in `ccc/infrastructure/src/evaluator/builtin.rs`
 2. Add type checking rules in `ccc/infrastructure/src/type_checker/ast_type_checker.rs`
 3. Add tests for both the evaluator and type checker

--- a/docs/spec/naming_convention.md
+++ b/docs/spec/naming_convention.md
@@ -1,0 +1,87 @@
+# Naming Convention
+
+## Overview
+
+This document defines the naming rules for built-in functions. All new functions must follow these rules, and existing functions that violate them should be renamed (see #12).
+
+## Rules
+
+### 1. Regular Functions: snake_case
+
+Functions that compute values use **snake_case**.
+
+- Single-word names are plain lowercase: `sqrt`, `abs`, `sin`, `sum`, `len`, `now`, `today`
+- Multi-word names use underscores: `current_timestamp`, `log2`, `log10`
+
+### 2. Constructors: PascalCase
+
+Functions that create a typed value use **PascalCase**, matching the type name they construct.
+
+| Constructor | Type |
+|-------------|------|
+| `DurationTime(...)` | duration |
+| `DateTime(...)` | datetime |
+| `Timestamp(...)` | timestamp |
+
+This visual distinction makes it clear that the call produces a specific domain type, not a derived numeric result.
+
+### 3. Operators and Keywords: lowercase
+
+Operators and keywords embedded in the grammar use **lowercase**.
+
+- Type cast keyword: `as`
+- Cast target types: `int`, `float`, `timestamp`, `datetime`
+
+## Naming Guidelines
+
+### Prefer full words over abbreviations
+
+Use descriptive names that read naturally. Abbreviations are acceptable only when they are universally understood in the domain.
+
+| Preferred | Avoid |
+|-----------|-------|
+| `mean` | `E` |
+| `variance` | `V` |
+| `median` | `med` |
+| `arcsin` | `asin` |
+
+Exception: `sqrt`, `abs`, `sin`, `cos`, `tan`, `log`, `len`, `prod`, `var`, `max`, `min` are standard abbreviations widely understood in math and programming.
+
+### Avoid prefixes for categories
+
+Do not prefix function names with their category.
+
+| Preferred | Avoid |
+|-----------|-------|
+| `sum` | `list_sum` |
+| `mean` | `stat_mean` |
+
+### Use `as` for type conversion, not functions
+
+Type conversions use the `as` operator, not conversion functions.
+
+| Preferred | Avoid |
+|-----------|-------|
+| `x as int` | `to_int(x)` |
+| `dt as timestamp` | `datetime_to_timestamp(dt)` |
+
+## Current Violations
+
+The following functions violate the naming convention and are tracked for renaming in #12:
+
+| Current Name | Issue | Expected Name |
+|-------------|-------|---------------|
+| `current_timestamp` | none (already compliant) | - |
+| `var` | ambiguous abbreviation | `variance` |
+
+Note: `var` is a standard abbreviation in statistics but could be confused with "variable" in programming contexts. Renaming to `variance` improves clarity.
+
+## Reference: Complete Function List
+
+### Regular Functions (snake_case)
+
+`sqrt`, `abs`, `sin`, `cos`, `tan`, `arcsin`, `arccos`, `arctan`, `log`, `log2`, `log10`, `floor`, `ceil`, `round`, `mean`, `var`, `max`, `min`, `median`, `len`, `sum`, `prod`, `head`, `tail`, `now`, `today`, `current_timestamp`
+
+### Constructors (PascalCase)
+
+`DurationTime`, `DateTime`, `Timestamp`


### PR DESCRIPTION
## Summary

- `docs/spec/naming_convention.md` を新規作成し、ビルトイン関数の命名規則を策定
  - 通常関数: **snake_case** (`sqrt`, `sum`, `current_timestamp`)
  - コンストラクタ: **PascalCase** (`DurationTime`, `DateTime`, `Timestamp`)
  - 演算子/キーワード: **lowercase** (`as`, `int`, `float`)
- 命名ガイドライン（略語の方針、カテゴリプレフィックス禁止、型変換は `as` を使用）を記載
- 現状の違反として `var` → `variance` のリネームを #12 で追跡
- `docs/contribute.md` から命名規則ドキュメントへのリンクを追加

## Test plan

- [x] ドキュメントのみの変更のため、既存テストが全てパスすることを確認

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)