### PR TITLE
Rename var to variance

### DIFF
--- a/ccc/infrastructure/src/evaluator/builtin.rs
+++ b/ccc/infrastructure/src/evaluator/builtin.rs
@@ -22,7 +22,7 @@ pub fn call_builtin(name: &str, arguments: &[Value]) -> Result<Value, CccError> 
         "sum" => list_sum(arguments),
         "prod" => list_prod(arguments),
         "mean" => list_mean(arguments),
-        "var" => list_var(arguments),
+        "variance" => list_var(arguments),
         "max" => list_max(arguments),
         "min" => list_min(arguments),
         "median" => list_median(arguments),
@@ -227,11 +227,11 @@ fn list_mean(arguments: &[Value]) -> Result<Value, CccError> {
 }
 
 fn list_var(arguments: &[Value]) -> Result<Value, CccError> {
-    let elements = expect_nonempty_list("var", arguments)?;
+    let elements = expect_nonempty_list("variance", arguments)?;
 
     match elements.first() {
         Some(Value::Integer(_) | Value::Float(_)) => {
-            let nums = collect_numbers("var", elements)?;
+            let nums = collect_numbers("variance", elements)?;
             let n = nums.len() as f64;
             let mean = nums.iter().sum::<f64>() / n;
             let variance = nums.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n;

--- a/ccc/infrastructure/src/type_checker/ast_type_checker.rs
+++ b/ccc/infrastructure/src/type_checker/ast_type_checker.rs
@@ -201,7 +201,7 @@ fn infer_function_return_type(
             require_list(name, &arg_types[0])?;
             Ok(StaticType::Integer)
         }
-        "sum" | "prod" | "mean" | "var" | "max" | "min" | "median" => {
+        "sum" | "prod" | "mean" | "variance" | "max" | "min" | "median" => {
             check_arg_count(name, arg_types, 1)?;
             require_list(name, &arg_types[0])?;
             Ok(StaticType::Unknown)

--- a/ccc/presentation/src/show_builtin.rs
+++ b/ccc/presentation/src/show_builtin.rs
@@ -84,7 +84,7 @@ const BUILTIN_CATEGORIES: &[BuiltinCategory] = &[
                 description: "Mean of duration elements",
             },
             BuiltinEntry {
-                signature: "var(l: list[int | float]) -> float",
+                signature: "variance(l: list[int | float]) -> float",
                 description: "Variance of numeric elements",
             },
             BuiltinEntry {

--- a/ccc/presentation/tests/cli_test.rs
+++ b/ccc/presentation/tests/cli_test.rs
@@ -559,39 +559,39 @@ fn evaluate_mean_empty_fails() {
     result.failure();
 }
 
-// --- var / V ---
+// --- variance ---
 
 #[test]
-fn evaluate_var_integers() {
+fn evaluate_variance_integers() {
     // Arrange
     let mut cmd = ccc();
 
     // Act
-    let result = cmd.arg("var([1, 2, 3, 4, 5])").assert();
+    let result = cmd.arg("variance([1, 2, 3, 4, 5])").assert();
 
     // Assert
     result.success().stdout("2\n");
 }
 
 #[test]
-fn evaluate_var_single_element() {
+fn evaluate_variance_single_element() {
     // Arrange
     let mut cmd = ccc();
 
     // Act
-    let result = cmd.arg("var([5])").assert();
+    let result = cmd.arg("variance([5])").assert();
 
     // Assert
     result.success().stdout("0\n");
 }
 
 #[test]
-fn evaluate_var_empty_fails() {
+fn evaluate_variance_empty_fails() {
     // Arrange
     let mut cmd = ccc();
 
     // Act
-    let result = cmd.arg("var([])").assert();
+    let result = cmd.arg("variance([])").assert();
 
     // Assert
     result.failure();
@@ -1161,7 +1161,7 @@ fn show_builtin_contains_all_function_names() {
         "ceil",
         "round",
         "mean",
-        "var",
+        "variance",
         "max",
         "min",
         "median",

--- a/docs/spec/naming_convention.md
+++ b/docs/spec/naming_convention.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document defines the naming rules for built-in functions. All new functions must follow these rules, and existing functions that violate them should be renamed (see #12).
+This document defines the naming rules for built-in functions. All new functions must follow these rules.
 
 ## Rules
 
@@ -45,7 +45,7 @@ Use descriptive names that read naturally. Abbreviations are acceptable only whe
 | `median` | `med` |
 | `arcsin` | `asin` |
 
-Exception: `sqrt`, `abs`, `sin`, `cos`, `tan`, `log`, `len`, `prod`, `var`, `max`, `min` are standard abbreviations widely understood in math and programming.
+Exception: `sqrt`, `abs`, `sin`, `cos`, `tan`, `log`, `len`, `prod`, `max`, `min` are standard abbreviations widely understood in math and programming.
 
 ### Avoid prefixes for categories
 
@@ -65,22 +65,11 @@ Type conversions use the `as` operator, not conversion functions.
 | `x as int` | `to_int(x)` |
 | `dt as timestamp` | `datetime_to_timestamp(dt)` |
 
-## Current Violations
-
-The following functions violate the naming convention and are tracked for renaming in #12:
-
-| Current Name | Issue | Expected Name |
-|-------------|-------|---------------|
-| `current_timestamp` | none (already compliant) | - |
-| `var` | ambiguous abbreviation | `variance` |
-
-Note: `var` is a standard abbreviation in statistics but could be confused with "variable" in programming contexts. Renaming to `variance` improves clarity.
-
 ## Reference: Complete Function List
 
 ### Regular Functions (snake_case)
 
-`sqrt`, `abs`, `sin`, `cos`, `tan`, `arcsin`, `arccos`, `arctan`, `log`, `log2`, `log10`, `floor`, `ceil`, `round`, `mean`, `var`, `max`, `min`, `median`, `len`, `sum`, `prod`, `head`, `tail`, `now`, `today`, `current_timestamp`
+`sqrt`, `abs`, `sin`, `cos`, `tan`, `arcsin`, `arccos`, `arctan`, `log`, `log2`, `log10`, `floor`, `ceil`, `round`, `mean`, `variance`, `max`, `min`, `median`, `len`, `sum`, `prod`, `head`, `tail`, `now`, `today`, `current_timestamp`
 
 ### Constructors (PascalCase)
 


### PR DESCRIPTION
## Summary

- `var` を `variance` にリネーム（プログラミング文脈での "variable" との曖昧さを解消）
- evaluator, type checker, show_builtin, CLI テスト, naming convention ドキュメントを一括更新

## Test plan

- [x] `variance([1, 2, 3, 4, 5])` → `2`
- [x] `variance([5])` → `0`
- [x] `variance([])` → エラー
- [x] `show builtin` に `variance` が含まれること

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)