### PR TITLE
Add release workflow with workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         id: version
         run: |
           version=$(grep -m1 '^version' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >>"$GITHUB_OUTPUT"
       - name: Check tag does not exist
         run: |
           if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  prepare:
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract version from Cargo.toml
+        id: version
+        run: |
+          version=$(grep -m1 '^version' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+      - name: Check tag does not exist
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag v${{ steps.version.outputs.version }} already exists"
+            exit 1
+          fi
+
+  build:
+    needs: prepare
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-24.04
+            artifact: ccc-x86_64-unknown-linux-gnu
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            artifact: ccc-x86_64-apple-darwin
+          - target: aarch64-apple-darwin
+            runner: macos-14
+            artifact: ccc-aarch64-apple-darwin
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/ccc dist/ccc
+          tar -czf ${{ matrix.artifact }}.tar.gz -C dist ccc
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.tar.gz
+
+  release:
+    needs: [prepare, build]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Create tag
+        run: |
+          git tag "v${{ needs.prepare.outputs.version }}"
+          git push origin "v${{ needs.prepare.outputs.version }}"
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ needs.prepare.outputs.version }}" \
+            --title "v${{ needs.prepare.outputs.version }}" \
+            --generate-notes \
+            artifacts/**/*.tar.gz


### PR DESCRIPTION
## Summary

- `workflow_dispatch` で手動トリガーするリリースワークフローを追加
- `Cargo.toml` の `workspace.package.version` からバージョンを読み取り、git tag と GitHub Release を作成
- Linux x86_64 (`ubuntu-24.04`)、macOS Intel (`macos-13`)、macOS Apple Silicon (`macos-14`) の3プラットフォームでバイナリをビルドし tar.gz で添付

## Workflow structure

1. **prepare**: バージョン抽出 + 既存タグの重複チェック
2. **build**: 3プラットフォームで並列ビルド + artifact アップロード
3. **release**: tag 作成 + GitHub Release 作成 (バイナリ添付)

## Test plan

- [ ] PR マージ後、Actions タブから workflow_dispatch で手動実行して Release が作成されることを確認

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)