### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "domain"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "thiserror",
@@ -233,7 +233,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "infrastructure"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "domain",
  "pest",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "presentation"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -513,7 +513,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "usecase"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "domain",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Shunsuke Tsuchiya"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- `Cargo.toml` の workspace.package.version を `0.1.0` → `0.2.0` にバンプ
- `cargo build` で `Cargo.lock` を再生成

## Background

初回 GitHub Release を作成するための準備。`.github/workflows/release.yml` (workflow_dispatch) は `Cargo.toml` の version を読み取り、`v<version>` タグと Release を生成する設計のため、まず main の version を `0.2.0` に上げてから Release ワークフローを起動する。

Closes #31

## Test plan

- [ ] CI (build/test) が green
- [ ] merge 後に `gh workflow run release.yml` を実行して v0.2.0 リリースを作成