### PR TITLE
Drop x86_64-apple-darwin from release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,6 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-24.04
             artifact: ccc-x86_64-unknown-linux-gnu
-          - target: x86_64-apple-darwin
-            runner: macos-13
-            artifact: ccc-x86_64-apple-darwin
           - target: aarch64-apple-darwin
             runner: macos-14
             artifact: ccc-aarch64-apple-darwin

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,7 @@
+extends: default
+
+rules:
+  line-length:
+    max: 120
+  truthy: disable
+  document-start: disable


### PR DESCRIPTION
## Summary

- リリースマトリックスから \`x86_64-apple-darwin\` (macos-13 / Intel Mac) を削除
- yamllint baseline (\`.yamllint.yml\`) を追加 (line-length 120, truthy / document-start disable)

## Background

v0.2.0 リリース実行 (https://github.com/shunsock/ccc/actions/runs/25415053406) で \`macos-13\` Intel runner が 1 時間以上 \`queued\` のまま滞留した。GitHub の Intel macOS runner 供給は縮小傾向にあり、個人 hobby プロジェクトとして Intel Mac サポートを維持するコストが見合わないと判断。Apple Silicon (macos-14 / aarch64) と Linux x86_64 のみを配布対象とする。

Closes #33

## Test plan

- [ ] CI green
- [ ] merge 後に \`gh workflow run release.yml\` を再実行して v0.2.0 リリースが完成する