### PR TITLE
Introduce time value objects to encode invariants in types

### DIFF
--- a/ccc/domain/src/ast.rs
+++ b/ccc/domain/src/ast.rs
@@ -77,8 +77,8 @@ pub enum Expression {
         hour: u8,
         minute: u8,
         second: u8,
-        /// Timezone offset in seconds from UTC.
-        offset_seconds: i32,
+        /// Timezone offset from UTC, validated at parse time.
+        offset: crate::time::UtcOffset,
     },
 }
 

--- a/ccc/domain/src/calendar.rs
+++ b/ccc/domain/src/calendar.rs
@@ -1,4 +1,4 @@
-use chrono::{Datelike, NaiveDate, TimeZone, Timelike};
+use chrono::NaiveDate;
 
 /// Returns the number of days in the given month (1-indexed) of the given year.
 /// Returns `None` if the month is out of range or the year is out of chrono's range.
@@ -13,38 +13,4 @@ pub fn days_in_month(year: i64, month: u8) -> Option<u8> {
         let end = NaiveDate::from_ymd_opt(year_i32, month as u32 + 1, 1)?;
         Some((end - start).num_days() as u8)
     }
-}
-
-/// Converts calendar components to epoch seconds (seconds since 1970-01-01T00:00:00 UTC).
-/// Returns `None` if the date/time components are invalid.
-pub fn calendar_to_epoch_seconds(
-    year: i64,
-    month: u8,
-    day: u8,
-    hour: u8,
-    minute: u8,
-    second: u8,
-) -> Option<i64> {
-    let year_i32 = i32::try_from(year).ok()?;
-    let naive = NaiveDate::from_ymd_opt(year_i32, month as u32, day as u32)?.and_hms_opt(
-        hour as u32,
-        minute as u32,
-        second as u32,
-    )?;
-    let utc = chrono::Utc.from_utc_datetime(&naive);
-    Some(utc.timestamp())
-}
-
-/// Converts epoch seconds to calendar components (year, month, day, hour, minute, second).
-pub fn epoch_seconds_to_calendar(epoch_seconds: i64) -> (i64, u8, u8, u8, u8, u8) {
-    let dt = chrono::DateTime::from_timestamp(epoch_seconds, 0)
-        .expect("epoch seconds out of chrono range");
-    (
-        dt.year() as i64,
-        dt.month() as u8,
-        dt.day() as u8,
-        dt.hour() as u8,
-        dt.minute() as u8,
-        dt.second() as u8,
-    )
 }

--- a/ccc/domain/src/lib.rs
+++ b/ccc/domain/src/lib.rs
@@ -3,6 +3,7 @@ pub mod calendar;
 pub mod error;
 pub mod interface;
 pub mod static_type;
+pub mod time;
 pub mod value;
 mod value_display;
 

--- a/ccc/domain/src/time/duration_seconds.rs
+++ b/ccc/domain/src/time/duration_seconds.rs
@@ -1,0 +1,61 @@
+use std::ops::{Add, Div, Mul, Neg, Sub};
+
+/// Signed time span as total seconds.
+///
+/// Distinguishes spans from epoch positions ([`super::EpochSeconds`]) at the
+/// type level, so the two kinds of "seconds" cannot be mixed up.
+/// Any i64 is a valid span; arithmetic follows plain integer semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DurationSeconds(i64);
+
+impl DurationSeconds {
+    pub fn from_seconds(seconds: i64) -> Self {
+        Self(seconds)
+    }
+
+    /// Total seconds of `HH:MM:SS` components.
+    /// `minutes`/`seconds` are `u8` because literals are validated to 0-59 at parse time.
+    pub fn from_hms(hours: i64, minutes: u8, seconds: u8) -> Self {
+        Self(hours * 3600 + minutes as i64 * 60 + seconds as i64)
+    }
+
+    pub fn seconds(self) -> i64 {
+        self.0
+    }
+}
+
+impl Add for DurationSeconds {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl Sub for DurationSeconds {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self {
+        Self(self.0 - rhs.0)
+    }
+}
+
+impl Neg for DurationSeconds {
+    type Output = Self;
+    fn neg(self) -> Self {
+        Self(-self.0)
+    }
+}
+
+impl Mul<i64> for DurationSeconds {
+    type Output = Self;
+    fn mul(self, scalar: i64) -> Self {
+        Self(self.0 * scalar)
+    }
+}
+
+/// Caller must reject a zero divisor first; division itself truncates.
+impl Div<i64> for DurationSeconds {
+    type Output = Self;
+    fn div(self, divisor: i64) -> Self {
+        Self(self.0 / divisor)
+    }
+}

--- a/ccc/domain/src/time/epoch_seconds.rs
+++ b/ccc/domain/src/time/epoch_seconds.rs
@@ -1,0 +1,76 @@
+use chrono::{Datelike, NaiveDate, TimeZone, Timelike};
+
+use super::duration_seconds::DurationSeconds;
+
+/// A point in time as seconds since 1970-01-01T00:00:00Z.
+///
+/// Invariant: the value is representable by chrono, so calendar conversion
+/// and display formatting never fail. Constructors return `None` instead of
+/// letting an unrepresentable instant exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EpochSeconds(i64);
+
+impl EpochSeconds {
+    /// Returns `None` if the instant is outside chrono's representable range.
+    pub fn from_seconds(seconds: i64) -> Option<Self> {
+        chrono::DateTime::from_timestamp(seconds, 0).map(|_| Self(seconds))
+    }
+
+    /// Builds an instant from calendar components interpreted as UTC.
+    /// Returns `None` for invalid dates (e.g. Feb 30) or out-of-range years.
+    pub fn from_calendar(
+        year: i64,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+    ) -> Option<Self> {
+        let year_i32 = i32::try_from(year).ok()?;
+        let naive = NaiveDate::from_ymd_opt(year_i32, month as u32, day as u32)?.and_hms_opt(
+            hour as u32,
+            minute as u32,
+            second as u32,
+        )?;
+        let utc = chrono::Utc.from_utc_datetime(&naive);
+        Some(Self(utc.timestamp()))
+    }
+
+    /// Calendar components (year, month, day, hour, minute, second) in UTC.
+    /// Infallible thanks to the construction invariant.
+    pub fn to_calendar(self) -> (i64, u8, u8, u8, u8, u8) {
+        let dt = chrono::DateTime::from_timestamp(self.0, 0)
+            .expect("EpochSeconds invariant guarantees chrono range");
+        (
+            dt.year() as i64,
+            dt.month() as u8,
+            dt.day() as u8,
+            dt.hour() as u8,
+            dt.minute() as u8,
+            dt.second() as u8,
+        )
+    }
+
+    pub fn seconds(self) -> i64 {
+        self.0
+    }
+
+    /// Moves forward by a span. `None` if the result leaves chrono's range.
+    pub fn checked_add(self, delta: DurationSeconds) -> Option<Self> {
+        self.0
+            .checked_add(delta.seconds())
+            .and_then(Self::from_seconds)
+    }
+
+    /// Moves backward by a span. `None` if the result leaves chrono's range.
+    pub fn checked_sub(self, delta: DurationSeconds) -> Option<Self> {
+        self.0
+            .checked_sub(delta.seconds())
+            .and_then(Self::from_seconds)
+    }
+
+    /// Signed span from `other` to `self`.
+    pub fn duration_since(self, other: EpochSeconds) -> DurationSeconds {
+        DurationSeconds::from_seconds(self.0 - other.0)
+    }
+}

--- a/ccc/domain/src/time/mod.rs
+++ b/ccc/domain/src/time/mod.rs
@@ -1,0 +1,16 @@
+//! Time-related value objects.
+//!
+//! Each type encodes one invariant at construction time, so downstream
+//! code (evaluation, display) never needs to re-validate:
+//!
+//! - [`DurationSeconds`]: a signed time span, distinct from epoch positions
+//! - [`EpochSeconds`]: a point in time guaranteed representable by chrono
+//! - [`UtcOffset`]: a timezone offset guaranteed displayable
+
+mod duration_seconds;
+mod epoch_seconds;
+mod utc_offset;
+
+pub use duration_seconds::DurationSeconds;
+pub use epoch_seconds::EpochSeconds;
+pub use utc_offset::UtcOffset;

--- a/ccc/domain/src/time/utc_offset.rs
+++ b/ccc/domain/src/time/utc_offset.rs
@@ -1,0 +1,26 @@
+/// Timezone offset from UTC in seconds.
+///
+/// Invariant: `|seconds| < 24h`, the range `chrono::FixedOffset` accepts.
+/// Constructing through [`UtcOffset::from_seconds`] guarantees that display
+/// formatting can never fail on an out-of-range offset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UtcOffset(i32);
+
+impl UtcOffset {
+    pub const UTC: Self = Self(0);
+
+    const MAX_ABS_SECONDS: i32 = 24 * 3600;
+
+    /// Returns `None` if the offset is outside ±24h (exclusive).
+    pub fn from_seconds(seconds: i32) -> Option<Self> {
+        (seconds.abs() < Self::MAX_ABS_SECONDS).then_some(Self(seconds))
+    }
+
+    pub fn seconds(self) -> i32 {
+        self.0
+    }
+
+    pub fn is_utc(self) -> bool {
+        self.0 == 0
+    }
+}

--- a/ccc/domain/src/value.rs
+++ b/ccc/domain/src/value.rs
@@ -1,15 +1,17 @@
+use crate::time::{DurationSeconds, EpochSeconds, UtcOffset};
+
 /// Represents a computed value in the calculator.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Integer(i64),
     Float(f64),
     List(Vec<Value>),
-    /// Duration stored as total seconds (signed to support negative durations).
-    DurationTime(i64),
-    /// DateTime stored as UTC epoch seconds with a display timezone offset.
+    /// Duration as a signed time span.
+    DurationTime(DurationSeconds),
+    /// DateTime as a UTC instant with a display timezone offset.
     DateTime {
-        epoch_seconds: i64,
-        offset_seconds: i32,
+        epoch: EpochSeconds,
+        offset: UtcOffset,
     },
     /// Unix timestamp in seconds. Stored as f64 to support sub-second precision.
     Timestamp(f64),

--- a/ccc/domain/src/value_display.rs
+++ b/ccc/domain/src/value_display.rs
@@ -1,5 +1,6 @@
 use chrono::{Datelike, FixedOffset, Timelike};
 
+use crate::time::{DurationSeconds, EpochSeconds, UtcOffset};
 use crate::value::Value;
 
 impl std::fmt::Display for Value {
@@ -8,12 +9,9 @@ impl std::fmt::Display for Value {
             Value::Integer(n) => write!(f, "{n}"),
             Value::Float(n) => write!(f, "{n}"),
             Value::List(elements) => format_list(f, elements),
-            Value::DateTime {
-                epoch_seconds,
-                offset_seconds,
-            } => format_datetime(f, *epoch_seconds, *offset_seconds),
+            Value::DateTime { epoch, offset } => format_datetime(f, *epoch, *offset),
             Value::Timestamp(ts) => format_timestamp(f, *ts),
-            Value::DurationTime(total_seconds) => format_duration(f, *total_seconds),
+            Value::DurationTime(span) => format_duration(f, *span),
         }
     }
 }
@@ -31,13 +29,14 @@ fn format_list(f: &mut std::fmt::Formatter<'_>, elements: &[Value]) -> std::fmt:
 
 fn format_datetime(
     f: &mut std::fmt::Formatter<'_>,
-    epoch_seconds: i64,
-    offset_seconds: i32,
+    epoch: EpochSeconds,
+    offset: UtcOffset,
 ) -> std::fmt::Result {
-    let offset = FixedOffset::east_opt(offset_seconds).expect("timezone offset out of range");
-    let dt = chrono::DateTime::from_timestamp(epoch_seconds, 0)
-        .expect("epoch seconds out of range")
-        .with_timezone(&offset);
+    // Both expect calls are infallible: the value objects validate at construction.
+    let fixed = FixedOffset::east_opt(offset.seconds()).expect("UtcOffset guarantees range");
+    let dt = chrono::DateTime::from_timestamp(epoch.seconds(), 0)
+        .expect("EpochSeconds guarantees range")
+        .with_timezone(&fixed);
     write!(
         f,
         "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
@@ -48,11 +47,11 @@ fn format_datetime(
         dt.minute(),
         dt.second()
     )?;
-    if offset_seconds == 0 {
+    if offset.is_utc() {
         write!(f, "Z")
     } else {
-        let sign = if offset_seconds >= 0 { '+' } else { '-' };
-        let abs_offset = offset_seconds.unsigned_abs();
+        let sign = if offset.seconds() >= 0 { '+' } else { '-' };
+        let abs_offset = offset.seconds().unsigned_abs();
         let offset_hours = abs_offset / 3600;
         let offset_minutes = (abs_offset % 3600) / 60;
         write!(f, "{sign}{offset_hours:02}:{offset_minutes:02}")
@@ -68,9 +67,9 @@ fn format_timestamp(f: &mut std::fmt::Formatter<'_>, ts: f64) -> std::fmt::Resul
     }
 }
 
-fn format_duration(f: &mut std::fmt::Formatter<'_>, total_seconds: i64) -> std::fmt::Result {
-    let negative = total_seconds < 0;
-    let abs_seconds = total_seconds.unsigned_abs();
+fn format_duration(f: &mut std::fmt::Formatter<'_>, span: DurationSeconds) -> std::fmt::Result {
+    let negative = span.seconds() < 0;
+    let abs_seconds = span.seconds().unsigned_abs();
     let hours = abs_seconds / 3600;
     let minutes = (abs_seconds % 3600) / 60;
     let seconds = abs_seconds % 60;

--- a/ccc/domain/src/value_test.rs
+++ b/ccc/domain/src/value_test.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+    use crate::time::{DurationSeconds, EpochSeconds, UtcOffset};
     use crate::value::Value;
 
     #[test]
@@ -218,7 +219,7 @@ mod tests {
     #[test]
     fn display_duration_time_basic() {
         // Arrange
-        let value = Value::DurationTime(10 * 3600 + 20 * 60 + 30);
+        let value = Value::DurationTime(DurationSeconds::from_seconds(10 * 3600 + 20 * 60 + 30));
 
         // Act
         let result = format!("{value}");
@@ -230,7 +231,7 @@ mod tests {
     #[test]
     fn display_duration_time_zero() {
         // Arrange
-        let value = Value::DurationTime(0);
+        let value = Value::DurationTime(DurationSeconds::from_seconds(0));
 
         // Act
         let result = format!("{value}");
@@ -242,7 +243,7 @@ mod tests {
     #[test]
     fn display_duration_time_negative() {
         // Arrange
-        let value = Value::DurationTime(-3600);
+        let value = Value::DurationTime(DurationSeconds::from_seconds(-3600));
 
         // Act
         let result = format!("{value}");
@@ -254,7 +255,7 @@ mod tests {
     #[test]
     fn display_duration_time_over_24_hours() {
         // Arrange: 26 hours 30 minutes
-        let value = Value::DurationTime(26 * 3600 + 30 * 60);
+        let value = Value::DurationTime(DurationSeconds::from_seconds(26 * 3600 + 30 * 60));
 
         // Act
         let result = format!("{value}");
@@ -266,7 +267,7 @@ mod tests {
     #[test]
     fn display_duration_time_seconds_only() {
         // Arrange
-        let value = Value::DurationTime(45);
+        let value = Value::DurationTime(DurationSeconds::from_seconds(45));
 
         // Act
         let result = format!("{value}");
@@ -278,7 +279,7 @@ mod tests {
     #[test]
     fn clone_duration_time() {
         // Arrange
-        let value = Value::DurationTime(3600);
+        let value = Value::DurationTime(DurationSeconds::from_seconds(3600));
 
         // Act
         let cloned = value.clone();
@@ -293,8 +294,8 @@ mod tests {
     fn display_datetime_utc() {
         // Arrange: 2026-01-01T00:00:00Z (epoch = 1767225600)
         let value = Value::DateTime {
-            epoch_seconds: 1_767_225_600,
-            offset_seconds: 0,
+            epoch: EpochSeconds::from_seconds(1_767_225_600).unwrap(),
+            offset: UtcOffset::from_seconds(0).unwrap(),
         };
 
         // Act
@@ -308,8 +309,8 @@ mod tests {
     fn display_datetime_positive_offset() {
         // Arrange: 2026-01-01T09:00:00+09:00 (same UTC instant as above)
         let value = Value::DateTime {
-            epoch_seconds: 1_767_225_600,
-            offset_seconds: 9 * 3600,
+            epoch: EpochSeconds::from_seconds(1_767_225_600).unwrap(),
+            offset: UtcOffset::from_seconds(9 * 3600).unwrap(),
         };
 
         // Act
@@ -323,8 +324,8 @@ mod tests {
     fn display_datetime_negative_offset() {
         // Arrange: 2025-12-31T19:00:00-05:00 (same UTC instant as above)
         let value = Value::DateTime {
-            epoch_seconds: 1_767_225_600,
-            offset_seconds: -5 * 3600,
+            epoch: EpochSeconds::from_seconds(1_767_225_600).unwrap(),
+            offset: UtcOffset::from_seconds(-5 * 3600).unwrap(),
         };
 
         // Act
@@ -338,8 +339,8 @@ mod tests {
     fn display_datetime_epoch() {
         // Arrange: Unix epoch
         let value = Value::DateTime {
-            epoch_seconds: 0,
-            offset_seconds: 0,
+            epoch: EpochSeconds::from_seconds(0).unwrap(),
+            offset: UtcOffset::from_seconds(0).unwrap(),
         };
 
         // Act
@@ -353,8 +354,8 @@ mod tests {
     fn clone_datetime() {
         // Arrange
         let value = Value::DateTime {
-            epoch_seconds: 0,
-            offset_seconds: 0,
+            epoch: EpochSeconds::from_seconds(0).unwrap(),
+            offset: UtcOffset::from_seconds(0).unwrap(),
         };
 
         // Act
@@ -369,21 +370,19 @@ mod tests {
     #[test]
     fn calendar_round_trip_epoch() {
         // Arrange & Act
-        use crate::calendar::{calendar_to_epoch_seconds, epoch_seconds_to_calendar};
-        let epoch = calendar_to_epoch_seconds(1970, 1, 1, 0, 0, 0).unwrap();
-        let (y, m, d, h, mi, s) = epoch_seconds_to_calendar(epoch);
+        let epoch = EpochSeconds::from_calendar(1970, 1, 1, 0, 0, 0).unwrap();
+        let (y, m, d, h, mi, s) = epoch.to_calendar();
 
         // Assert
-        assert_eq!(epoch, 0);
+        assert_eq!(epoch.seconds(), 0);
         assert_eq!((y, m, d, h, mi, s), (1970, 1, 1, 0, 0, 0));
     }
 
     #[test]
     fn calendar_round_trip_2026() {
         // Arrange & Act
-        use crate::calendar::{calendar_to_epoch_seconds, epoch_seconds_to_calendar};
-        let epoch = calendar_to_epoch_seconds(2026, 6, 15, 12, 30, 45).unwrap();
-        let (y, m, d, h, mi, s) = epoch_seconds_to_calendar(epoch);
+        let epoch = EpochSeconds::from_calendar(2026, 6, 15, 12, 30, 45).unwrap();
+        let (y, m, d, h, mi, s) = epoch.to_calendar();
 
         // Assert
         assert_eq!((y, m, d, h, mi, s), (2026, 6, 15, 12, 30, 45));
@@ -392,9 +391,8 @@ mod tests {
     #[test]
     fn calendar_leap_year_feb_29() {
         // Arrange & Act
-        use crate::calendar::{calendar_to_epoch_seconds, epoch_seconds_to_calendar};
-        let epoch = calendar_to_epoch_seconds(2024, 2, 29, 0, 0, 0).unwrap();
-        let (y, m, d, h, mi, s) = epoch_seconds_to_calendar(epoch);
+        let epoch = EpochSeconds::from_calendar(2024, 2, 29, 0, 0, 0).unwrap();
+        let (y, m, d, h, mi, s) = epoch.to_calendar();
 
         // Assert
         assert_eq!((y, m, d, h, mi, s), (2024, 2, 29, 0, 0, 0));
@@ -403,10 +401,9 @@ mod tests {
     #[test]
     fn calendar_invalid_date_returns_none() {
         // Arrange & Act & Assert
-        use crate::calendar::calendar_to_epoch_seconds;
-        assert!(calendar_to_epoch_seconds(2025, 2, 29, 0, 0, 0).is_none());
-        assert!(calendar_to_epoch_seconds(2026, 13, 1, 0, 0, 0).is_none());
-        assert!(calendar_to_epoch_seconds(2026, 1, 1, 25, 0, 0).is_none());
+        assert!(EpochSeconds::from_calendar(2025, 2, 29, 0, 0, 0).is_none());
+        assert!(EpochSeconds::from_calendar(2026, 13, 1, 0, 0, 0).is_none());
+        assert!(EpochSeconds::from_calendar(2026, 1, 1, 25, 0, 0).is_none());
     }
 
     #[test]

--- a/ccc/infrastructure/src/evaluator/ast_evaluator.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator.rs
@@ -1,6 +1,7 @@
 use domain::ast::{AbstractSyntaxTree, Expression};
 use domain::error::CccError;
 use domain::interface::evaluator::CccEvaluator;
+use domain::time::{DurationSeconds, EpochSeconds};
 use domain::value::Value;
 
 use super::binary_operation::evaluate_binary;
@@ -54,10 +55,9 @@ pub(super) fn evaluate_expression(expression: &Expression) -> Result<Value, CccE
             hours,
             minutes,
             seconds,
-        } => {
-            let total_seconds = (*hours) * 3600 + (*minutes as i64) * 60 + (*seconds as i64);
-            Ok(Value::DurationTime(total_seconds))
-        }
+        } => Ok(Value::DurationTime(DurationSeconds::from_hms(
+            *hours, *minutes, *seconds,
+        ))),
         Expression::DateTime {
             year,
             month,
@@ -65,17 +65,18 @@ pub(super) fn evaluate_expression(expression: &Expression) -> Result<Value, CccE
             hour,
             minute,
             second,
-            offset_seconds,
+            offset,
         } => {
-            let local_epoch = domain::calendar::calendar_to_epoch_seconds(
-                *year, *month, *day, *hour, *minute, *second,
-            )
-            .ok_or_else(|| CccError::eval("invalid datetime components"))?;
+            let local_epoch =
+                EpochSeconds::from_calendar(*year, *month, *day, *hour, *minute, *second)
+                    .ok_or_else(|| CccError::eval("invalid datetime components"))?;
             // Convert local time to UTC by subtracting the offset
-            let utc_epoch = local_epoch - (*offset_seconds as i64);
+            let utc_epoch = local_epoch
+                .checked_sub(DurationSeconds::from_seconds(offset.seconds() as i64))
+                .ok_or_else(|| CccError::eval("datetime out of range"))?;
             Ok(Value::DateTime {
-                epoch_seconds: utc_epoch,
-                offset_seconds: *offset_seconds,
+                epoch: utc_epoch,
+                offset: *offset,
             })
         }
     }

--- a/ccc/infrastructure/src/evaluator/ast_evaluator_test.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator_test.rs
@@ -5,6 +5,7 @@ mod tests {
     };
     use domain::error::CccError;
     use domain::interface::evaluator::CccEvaluator;
+    use domain::time::{DurationSeconds, EpochSeconds, UtcOffset};
     use domain::value::Value;
 
     use crate::evaluator::AstEvaluator;
@@ -969,7 +970,7 @@ mod tests {
         // Assert
         assert_eq!(
             result.unwrap(),
-            Value::DurationTime(10 * 3600 + 20 * 60 + 30)
+            Value::DurationTime(DurationSeconds::from_seconds(10 * 3600 + 20 * 60 + 30))
         );
     }
 
@@ -986,7 +987,10 @@ mod tests {
         let result = eval(expression);
 
         // Assert
-        assert_eq!(result.unwrap(), Value::DurationTime(0));
+        assert_eq!(
+            result.unwrap(),
+            Value::DurationTime(DurationSeconds::from_seconds(0))
+        );
     }
 
     #[test]
@@ -1005,7 +1009,10 @@ mod tests {
         let result = eval(expression);
 
         // Assert
-        assert_eq!(result.unwrap(), Value::DurationTime(1 * 3600 + 30 * 60));
+        assert_eq!(
+            result.unwrap(),
+            Value::DurationTime(DurationSeconds::from_seconds(1 * 3600 + 30 * 60))
+        );
     }
 
     #[test]
@@ -1027,7 +1034,9 @@ mod tests {
         // Assert
         assert_eq!(
             result.unwrap(),
-            Value::DurationTime(1 * 86400 + 2 * 3600 + 30 * 60)
+            Value::DurationTime(DurationSeconds::from_seconds(
+                1 * 86400 + 2 * 3600 + 30 * 60
+            ))
         );
     }
 
@@ -1062,7 +1071,10 @@ mod tests {
         let result = eval(expression);
 
         // Assert
-        assert_eq!(result.unwrap(), Value::DurationTime(-3600));
+        assert_eq!(
+            result.unwrap(),
+            Value::DurationTime(DurationSeconds::from_seconds(-3600))
+        );
     }
 
     // --- DateTime ---
@@ -1077,21 +1089,17 @@ mod tests {
             hour: 0,
             minute: 0,
             second: 0,
-            offset_seconds: 0,
+            offset: UtcOffset::from_seconds(0).unwrap(),
         };
 
         // Act
         let result = eval(expression).unwrap();
 
         // Assert
-        if let Value::DateTime {
-            epoch_seconds,
-            offset_seconds,
-        } = result
-        {
-            assert_eq!(offset_seconds, 0);
+        if let Value::DateTime { epoch, offset } = result {
+            assert_eq!(offset, UtcOffset::UTC);
             // Verify round-trip
-            let (y, m, d, h, mi, s) = domain::calendar::epoch_seconds_to_calendar(epoch_seconds);
+            let (y, m, d, h, mi, s) = epoch.to_calendar();
             assert_eq!((y, m, d, h, mi, s), (2026, 1, 1, 0, 0, 0));
         } else {
             panic!("expected DateTime");
@@ -1108,20 +1116,16 @@ mod tests {
             hour: 9,
             minute: 0,
             second: 0,
-            offset_seconds: 9 * 3600,
+            offset: UtcOffset::from_seconds(9 * 3600).unwrap(),
         };
 
         // Act
         let result = eval(expression).unwrap();
 
         // Assert: same UTC instant as 2026-01-01T00:00:00Z
-        if let Value::DateTime {
-            epoch_seconds,
-            offset_seconds,
-        } = result
-        {
-            assert_eq!(offset_seconds, 9 * 3600);
-            let (y, m, d, h, mi, s) = domain::calendar::epoch_seconds_to_calendar(epoch_seconds);
+        if let Value::DateTime { epoch, offset } = result {
+            assert_eq!(offset, UtcOffset::from_seconds(9 * 3600).unwrap());
+            let (y, m, d, h, mi, s) = epoch.to_calendar();
             assert_eq!((y, m, d, h, mi, s), (2026, 1, 1, 0, 0, 0));
         } else {
             panic!("expected DateTime");
@@ -1147,13 +1151,9 @@ mod tests {
         let result = eval(expression).unwrap();
 
         // Assert
-        if let Value::DateTime {
-            epoch_seconds,
-            offset_seconds,
-        } = result
-        {
-            assert_eq!(offset_seconds, 0); // constructor defaults to UTC
-            let (y, m, d, h, mi, s) = domain::calendar::epoch_seconds_to_calendar(epoch_seconds);
+        if let Value::DateTime { epoch, offset } = result {
+            assert_eq!(offset, UtcOffset::UTC); // constructor defaults to UTC
+            let (y, m, d, h, mi, s) = epoch.to_calendar();
             assert_eq!((y, m, d, h, mi, s), (2026, 6, 15, 12, 30, 0));
         } else {
             panic!("expected DateTime");
@@ -1209,7 +1209,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
         };
 
@@ -1314,8 +1314,8 @@ mod tests {
         assert_eq!(
             result,
             Value::DateTime {
-                epoch_seconds: 0,
-                offset_seconds: 0,
+                epoch: EpochSeconds::from_seconds(0).unwrap(),
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }
         );
     }
@@ -1343,7 +1343,10 @@ mod tests {
         let result = eval(expression);
 
         // Assert
-        assert_eq!(result.unwrap(), Value::DurationTime(5400));
+        assert_eq!(
+            result.unwrap(),
+            Value::DurationTime(DurationSeconds::from_seconds(5400))
+        );
     }
 
     #[test]
@@ -1367,7 +1370,10 @@ mod tests {
         let result = eval(expression);
 
         // Assert
-        assert_eq!(result.unwrap(), Value::DurationTime(5400));
+        assert_eq!(
+            result.unwrap(),
+            Value::DurationTime(DurationSeconds::from_seconds(5400))
+        );
     }
 
     #[test]
@@ -1391,7 +1397,10 @@ mod tests {
         let result = eval(expression);
 
         // Assert
-        assert_eq!(result.unwrap(), Value::DurationTime(-3600));
+        assert_eq!(
+            result.unwrap(),
+            Value::DurationTime(DurationSeconds::from_seconds(-3600))
+        );
     }
 
     #[test]
@@ -1411,7 +1420,10 @@ mod tests {
         let result = eval(expression);
 
         // Assert
-        assert_eq!(result.unwrap(), Value::DurationTime(10800));
+        assert_eq!(
+            result.unwrap(),
+            Value::DurationTime(DurationSeconds::from_seconds(10800))
+        );
     }
 
     #[test]
@@ -1431,7 +1443,10 @@ mod tests {
         let result = eval(expression);
 
         // Assert
-        assert_eq!(result.unwrap(), Value::DurationTime(10800));
+        assert_eq!(
+            result.unwrap(),
+            Value::DurationTime(DurationSeconds::from_seconds(10800))
+        );
     }
 
     #[test]
@@ -1451,7 +1466,10 @@ mod tests {
         let result = eval(expression);
 
         // Assert
-        assert_eq!(result.unwrap(), Value::DurationTime(5400));
+        assert_eq!(
+            result.unwrap(),
+            Value::DurationTime(DurationSeconds::from_seconds(5400))
+        );
     }
 
     #[test]
@@ -1466,7 +1484,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
             right: Box::new(Expression::DurationTime {
                 hours: 1,
@@ -1479,13 +1497,9 @@ mod tests {
         let result = eval(expression).unwrap();
 
         // Assert
-        if let Value::DateTime {
-            epoch_seconds,
-            offset_seconds,
-        } = result
-        {
-            assert_eq!(offset_seconds, 0);
-            let (y, m, d, h, mi, s) = domain::calendar::epoch_seconds_to_calendar(epoch_seconds);
+        if let Value::DateTime { epoch, offset } = result {
+            assert_eq!(offset, UtcOffset::UTC);
+            let (y, m, d, h, mi, s) = epoch.to_calendar();
             assert_eq!((y, m, d, h, mi, s), (2026, 1, 1, 1, 30, 0));
         } else {
             panic!("expected DateTime");
@@ -1504,7 +1518,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
             right: Box::new(Expression::DateTime {
                 year: 2026,
@@ -1513,7 +1527,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
         };
 
@@ -1521,7 +1535,10 @@ mod tests {
         let result = eval(expression);
 
         // Assert: 24 hours = 86400 seconds
-        assert_eq!(result.unwrap(), Value::DurationTime(86400));
+        assert_eq!(
+            result.unwrap(),
+            Value::DurationTime(DurationSeconds::from_seconds(86400))
+        );
     }
 
     #[test]
@@ -1536,7 +1553,7 @@ mod tests {
                 hour: 9,
                 minute: 0,
                 second: 0,
-                offset_seconds: 9 * 3600,
+                offset: UtcOffset::from_seconds(9 * 3600).unwrap(),
             }),
             right: Box::new(Expression::DurationTime {
                 hours: 1,
@@ -1549,8 +1566,8 @@ mod tests {
         let result = eval(expression).unwrap();
 
         // Assert: offset preserved
-        if let Value::DateTime { offset_seconds, .. } = result {
-            assert_eq!(offset_seconds, 9 * 3600);
+        if let Value::DateTime { offset, .. } = result {
+            assert_eq!(offset, UtcOffset::from_seconds(9 * 3600).unwrap());
         } else {
             panic!("expected DateTime");
         }
@@ -1598,7 +1615,10 @@ mod tests {
         let result = eval(expression);
 
         // Assert
-        assert_eq!(result.unwrap(), Value::DurationTime(3600));
+        assert_eq!(
+            result.unwrap(),
+            Value::DurationTime(DurationSeconds::from_seconds(3600))
+        );
     }
 
     #[test]
@@ -1613,7 +1633,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
             right: Box::new(Expression::DateTime {
                 year: 2026,
@@ -1622,7 +1642,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
         };
 
@@ -1678,13 +1698,9 @@ mod tests {
         let result = eval(expression).unwrap();
 
         // Assert
-        if let Value::DateTime {
-            epoch_seconds,
-            offset_seconds,
-        } = result
-        {
-            assert_eq!(offset_seconds, 0);
-            let (y, m, d, h, mi, s) = domain::calendar::epoch_seconds_to_calendar(epoch_seconds);
+        if let Value::DateTime { epoch, offset } = result {
+            assert_eq!(offset, UtcOffset::UTC);
+            let (y, m, d, h, mi, s) = epoch.to_calendar();
             assert_eq!((y, m, d, h, mi, s), (2026, 6, 15, 12, 30, 0));
         } else {
             panic!("expected DateTime");
@@ -1705,13 +1721,9 @@ mod tests {
         let result = eval(expression).unwrap();
 
         // Assert
-        if let Value::DateTime {
-            epoch_seconds,
-            offset_seconds,
-        } = result
-        {
-            assert!(epoch_seconds > 1_700_000_000); // after 2023
-            assert_eq!(offset_seconds, 0); // UTC
+        if let Value::DateTime { epoch, offset } = result {
+            assert!(epoch.seconds() > 1_700_000_000); // after 2023
+            assert!(offset.is_utc());
         } else {
             panic!("expected DateTime");
         }
@@ -1729,13 +1741,9 @@ mod tests {
         let result = eval(expression).unwrap();
 
         // Assert
-        if let Value::DateTime {
-            epoch_seconds,
-            offset_seconds,
-        } = result
-        {
-            assert_eq!(epoch_seconds % 86400, 0); // midnight
-            assert_eq!(offset_seconds, 0);
+        if let Value::DateTime { epoch, offset } = result {
+            assert_eq!(epoch.seconds() % 86400, 0); // midnight
+            assert!(offset.is_utc());
         } else {
             panic!("expected DateTime");
         }

--- a/ccc/infrastructure/src/evaluator/binary_datetime.rs
+++ b/ccc/infrastructure/src/evaluator/binary_datetime.rs
@@ -1,5 +1,6 @@
 use domain::ast::BinaryOperation;
 use domain::error::CccError;
+use domain::time::{DurationSeconds, EpochSeconds, UtcOffset};
 use domain::value::Value;
 
 use super::binary_operation::unsupported_binary_op;
@@ -7,31 +8,28 @@ use super::binary_operation::unsupported_binary_op;
 /// DateTime ± DurationTime → DateTime (the display offset is preserved)
 pub(super) fn add_duration_to_datetime(
     operator: &BinaryOperation,
-    epoch_seconds: i64,
-    offset_seconds: i32,
-    duration: i64,
+    epoch: EpochSeconds,
+    offset: UtcOffset,
+    duration: DurationSeconds,
 ) -> Result<Value, CccError> {
-    match operator {
-        BinaryOperation::Add => Ok(Value::DateTime {
-            epoch_seconds: epoch_seconds + duration,
-            offset_seconds,
-        }),
-        BinaryOperation::Subtract => Ok(Value::DateTime {
-            epoch_seconds: epoch_seconds - duration,
-            offset_seconds,
-        }),
-        _ => Err(unsupported_binary_op(operator, "datetime", "duration")),
-    }
+    let moved = match operator {
+        BinaryOperation::Add => epoch.checked_add(duration),
+        BinaryOperation::Subtract => epoch.checked_sub(duration),
+        _ => return Err(unsupported_binary_op(operator, "datetime", "duration")),
+    };
+    moved
+        .map(|epoch| Value::DateTime { epoch, offset })
+        .ok_or_else(|| CccError::eval("datetime out of range"))
 }
 
 /// DateTime - DateTime → DurationTime
 pub(super) fn subtract_datetimes(
     operator: &BinaryOperation,
-    left_epoch: i64,
-    right_epoch: i64,
+    left: EpochSeconds,
+    right: EpochSeconds,
 ) -> Result<Value, CccError> {
     match operator {
-        BinaryOperation::Subtract => Ok(Value::DurationTime(left_epoch - right_epoch)),
+        BinaryOperation::Subtract => Ok(Value::DurationTime(left.duration_since(right))),
         _ => Err(unsupported_binary_op(operator, "datetime", "datetime")),
     }
 }
@@ -40,11 +38,12 @@ pub(super) fn subtract_datetimes(
 pub(super) fn add_duration_to_timestamp(
     operator: &BinaryOperation,
     timestamp: f64,
-    duration: i64,
+    duration: DurationSeconds,
 ) -> Result<Value, CccError> {
+    let delta = duration.seconds() as f64;
     match operator {
-        BinaryOperation::Add => Ok(Value::Timestamp(timestamp + duration as f64)),
-        BinaryOperation::Subtract => Ok(Value::Timestamp(timestamp - duration as f64)),
+        BinaryOperation::Add => Ok(Value::Timestamp(timestamp + delta)),
+        BinaryOperation::Subtract => Ok(Value::Timestamp(timestamp - delta)),
         _ => Err(unsupported_binary_op(operator, "timestamp", "duration")),
     }
 }
@@ -56,7 +55,9 @@ pub(super) fn subtract_timestamps(
     right: f64,
 ) -> Result<Value, CccError> {
     match operator {
-        BinaryOperation::Subtract => Ok(Value::DurationTime((left - right) as i64)),
+        BinaryOperation::Subtract => Ok(Value::DurationTime(DurationSeconds::from_seconds(
+            (left - right) as i64,
+        ))),
         _ => Err(unsupported_binary_op(operator, "timestamp", "timestamp")),
     }
 }

--- a/ccc/infrastructure/src/evaluator/binary_duration.rs
+++ b/ccc/infrastructure/src/evaluator/binary_duration.rs
@@ -1,5 +1,6 @@
 use domain::ast::BinaryOperation;
 use domain::error::CccError;
+use domain::time::DurationSeconds;
 use domain::value::Value;
 
 use super::binary_operation::unsupported_binary_op;
@@ -7,8 +8,8 @@ use super::binary_operation::unsupported_binary_op;
 /// DurationTime ± DurationTime → DurationTime
 pub(super) fn combine_durations(
     operator: &BinaryOperation,
-    left: i64,
-    right: i64,
+    left: DurationSeconds,
+    right: DurationSeconds,
 ) -> Result<Value, CccError> {
     match operator {
         BinaryOperation::Add => Ok(Value::DurationTime(left + right)),
@@ -20,7 +21,7 @@ pub(super) fn combine_durations(
 /// DurationTime */÷ Integer → DurationTime
 pub(super) fn scale_duration_by_integer(
     operator: &BinaryOperation,
-    duration: i64,
+    duration: DurationSeconds,
     scalar: i64,
 ) -> Result<Value, CccError> {
     match operator {
@@ -39,10 +40,10 @@ pub(super) fn scale_duration_by_integer(
 pub(super) fn multiply_integer_by_duration(
     operator: &BinaryOperation,
     scalar: i64,
-    duration: i64,
+    duration: DurationSeconds,
 ) -> Result<Value, CccError> {
     match operator {
-        BinaryOperation::Multiply => Ok(Value::DurationTime(scalar * duration)),
+        BinaryOperation::Multiply => Ok(Value::DurationTime(duration * scalar)),
         _ => Err(unsupported_binary_op(operator, "integer", "duration")),
     }
 }

--- a/ccc/infrastructure/src/evaluator/binary_operation.rs
+++ b/ccc/infrastructure/src/evaluator/binary_operation.rs
@@ -32,21 +32,12 @@ pub(super) fn evaluate_binary(
         }
 
         // DateTime combinations
-        (
-            Value::DateTime {
-                epoch_seconds,
-                offset_seconds,
-            },
-            Value::DurationTime(d),
-        ) => add_duration_to_datetime(operator, *epoch_seconds, *offset_seconds, *d),
-        (
-            Value::DateTime {
-                epoch_seconds: l, ..
-            },
-            Value::DateTime {
-                epoch_seconds: r, ..
-            },
-        ) => subtract_datetimes(operator, *l, *r),
+        (Value::DateTime { epoch, offset }, Value::DurationTime(d)) => {
+            add_duration_to_datetime(operator, *epoch, *offset, *d)
+        }
+        (Value::DateTime { epoch: l, .. }, Value::DateTime { epoch: r, .. }) => {
+            subtract_datetimes(operator, *l, *r)
+        }
 
         // Timestamp combinations
         (Value::Timestamp(ts), Value::DurationTime(d)) => {

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_constructor.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_constructor.rs
@@ -1,4 +1,5 @@
 use domain::error::CccError;
+use domain::time::{DurationSeconds, EpochSeconds, UtcOffset};
 use domain::value::Value;
 
 use super::builtin_helpers::{expect_single_arg, to_f64, to_i64_strict};
@@ -28,7 +29,9 @@ pub fn duration_time_constructor(arguments: &[Value]) -> Result<Value, CccError>
     };
 
     let total_seconds = days * 86400 + hours * 3600 + minutes * 60 + seconds;
-    Ok(Value::DurationTime(total_seconds))
+    Ok(Value::DurationTime(DurationSeconds::from_seconds(
+        total_seconds,
+    )))
 }
 
 pub fn datetime_constructor(arguments: &[Value]) -> Result<Value, CccError> {
@@ -46,7 +49,7 @@ pub fn datetime_constructor(arguments: &[Value]) -> Result<Value, CccError> {
     let minute = to_i64_strict(&arguments[4], "minute")?;
     let second = to_i64_strict(&arguments[5], "second")?;
 
-    let epoch_seconds = domain::calendar::calendar_to_epoch_seconds(
+    let epoch = EpochSeconds::from_calendar(
         year,
         month as u8,
         day as u8,
@@ -61,8 +64,8 @@ pub fn datetime_constructor(arguments: &[Value]) -> Result<Value, CccError> {
     })?;
 
     Ok(Value::DateTime {
-        epoch_seconds,
-        offset_seconds: 0,
+        epoch,
+        offset: UtcOffset::UTC,
     })
 }
 

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_extremum.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_extremum.rs
@@ -1,4 +1,5 @@
 use domain::error::CccError;
+use domain::time::DurationSeconds;
 use domain::value::Value;
 
 use super::builtin_helpers::{
@@ -17,9 +18,9 @@ pub fn list_extremum(
     match elements.first() {
         Some(Value::DurationTime(_)) => {
             let secs = collect_seconds(name, elements)?;
-            Ok(Value::DurationTime(
+            Ok(Value::DurationTime(DurationSeconds::from_seconds(
                 secs.into_iter().reduce(sec_reduce).unwrap(),
-            ))
+            )))
         }
         Some(Value::Integer(_)) => {
             let ints = collect_integers(name, elements)?;

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_helpers/collection.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_helpers/collection.rs
@@ -18,7 +18,7 @@ pub fn collect_seconds(name: &str, elements: &[Value]) -> Result<Vec<i64>, CccEr
     elements
         .iter()
         .map(|e| match e {
-            Value::DurationTime(s) => Ok(*s),
+            Value::DurationTime(s) => Ok(s.seconds()),
             _ => Err(CccError::eval(format!(
                 "{name}: list elements must be the same type"
             ))),

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_helpers/conversion.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_helpers/conversion.rs
@@ -7,7 +7,7 @@ pub fn to_f64(value: &Value) -> Result<f64, CccError> {
         Value::Float(n) => Ok(*n),
         _ => Err(CccError::eval(format!(
             "expected number, got {}",
-            value_type_name(value)
+            value.type_name()
         ))),
     }
 }
@@ -16,16 +16,5 @@ pub fn to_i64_strict(value: &Value, param_name: &str) -> Result<i64, CccError> {
     match value {
         Value::Integer(n) => Ok(*n),
         _ => Err(CccError::eval(format!("{param_name}: expected integer"))),
-    }
-}
-
-pub fn value_type_name(value: &Value) -> &'static str {
-    match value {
-        Value::Integer(_) => "integer",
-        Value::Float(_) => "float",
-        Value::List(_) => "list",
-        Value::DurationTime(_) => "duration",
-        Value::DateTime { .. } => "datetime",
-        Value::Timestamp(_) => "timestamp",
     }
 }

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_helpers/mod.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_helpers/mod.rs
@@ -4,4 +4,4 @@ mod conversion;
 
 pub use argument::{expect_no_args, expect_nonempty_list, expect_single_arg, expect_single_list};
 pub use collection::{collect_integers, collect_numbers, collect_seconds, fold_numbers};
-pub use conversion::{to_f64, to_i64_strict, value_type_name};
+pub use conversion::{to_f64, to_i64_strict};

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_list.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_list.rs
@@ -1,6 +1,7 @@
 use std::ops::{Add, Mul};
 
 use domain::error::CccError;
+use domain::time::DurationSeconds;
 use domain::value::Value;
 
 use super::builtin_helpers::{collect_seconds, expect_single_list, fold_numbers};
@@ -17,7 +18,9 @@ pub fn list_sum(arguments: &[Value]) -> Result<Value, CccError> {
         None => Ok(Value::Integer(0)),
         Some(Value::DurationTime(_)) => {
             let secs = collect_seconds("sum", elements)?;
-            Ok(Value::DurationTime(secs.iter().sum()))
+            Ok(Value::DurationTime(DurationSeconds::from_seconds(
+                secs.iter().sum(),
+            )))
         }
         _ => fold_numbers("sum", elements, 0, 0.0, i64::wrapping_add, f64::add),
     }

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_math.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_math.rs
@@ -1,7 +1,7 @@
 use domain::error::CccError;
 use domain::value::Value;
 
-use super::builtin_helpers::{expect_single_arg, to_f64, value_type_name};
+use super::builtin_helpers::{expect_single_arg, to_f64};
 
 pub fn unary_float_function(
     name: &str,
@@ -20,7 +20,7 @@ pub fn unary_absolute(arguments: &[Value]) -> Result<Value, CccError> {
         Value::Float(n) => Ok(Value::Float(n.abs())),
         _ => Err(CccError::eval(format!(
             "abs: expected number, got {}",
-            value_type_name(arg)
+            arg.type_name()
         ))),
     }
 }

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_statistics.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_statistics.rs
@@ -1,4 +1,5 @@
 use domain::error::CccError;
+use domain::time::DurationSeconds;
 use domain::value::Value;
 
 use super::builtin_helpers::{collect_numbers, collect_seconds, expect_nonempty_list};
@@ -10,7 +11,9 @@ pub fn list_mean(arguments: &[Value]) -> Result<Value, CccError> {
         Some(Value::DurationTime(_)) => {
             let secs = collect_seconds("mean", elements)?;
             let total: i64 = secs.iter().sum();
-            Ok(Value::DurationTime(total / secs.len() as i64))
+            Ok(Value::DurationTime(DurationSeconds::from_seconds(
+                total / secs.len() as i64,
+            )))
         }
         _ => {
             let nums = collect_numbers("mean", elements)?;
@@ -36,7 +39,9 @@ pub fn list_median(arguments: &[Value]) -> Result<Value, CccError> {
         Some(Value::DurationTime(_)) => {
             let mut secs = collect_seconds("median", elements)?;
             secs.sort();
-            Ok(Value::DurationTime(median_sorted_i64(&secs)))
+            Ok(Value::DurationTime(DurationSeconds::from_seconds(
+                median_sorted_i64(&secs),
+            )))
         }
         _ => {
             let mut nums = collect_numbers("median", elements)?;

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_time.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_time.rs
@@ -1,4 +1,5 @@
 use domain::error::CccError;
+use domain::time::{EpochSeconds, UtcOffset};
 use domain::value::Value;
 
 use super::builtin_helpers::expect_no_args;
@@ -12,9 +13,11 @@ fn current_epoch() -> Result<std::time::Duration, CccError> {
 pub fn now_function(arguments: &[Value]) -> Result<Value, CccError> {
     expect_no_args("now", arguments)?;
     let epoch = current_epoch()?;
+    let epoch = EpochSeconds::from_seconds(epoch.as_secs() as i64)
+        .ok_or_else(|| CccError::eval("system time out of range"))?;
     Ok(Value::DateTime {
-        epoch_seconds: epoch.as_secs() as i64,
-        offset_seconds: 0,
+        epoch,
+        offset: UtcOffset::UTC,
     })
 }
 
@@ -23,9 +26,11 @@ pub fn today_function(arguments: &[Value]) -> Result<Value, CccError> {
     let epoch = current_epoch()?;
     let secs = epoch.as_secs() as i64;
     let day_seconds = secs - (secs % 86400);
+    let epoch = EpochSeconds::from_seconds(day_seconds)
+        .ok_or_else(|| CccError::eval("system time out of range"))?;
     Ok(Value::DateTime {
-        epoch_seconds: day_seconds,
-        offset_seconds: 0,
+        epoch,
+        offset: UtcOffset::UTC,
     })
 }
 

--- a/ccc/infrastructure/src/evaluator/type_cast.rs
+++ b/ccc/infrastructure/src/evaluator/type_cast.rs
@@ -1,5 +1,6 @@
 use domain::ast::CastTargetType;
 use domain::error::CccError;
+use domain::time::{EpochSeconds, UtcOffset};
 use domain::value::Value;
 
 use super::value_conversion::{to_f64, to_i64};
@@ -18,17 +19,19 @@ pub(super) fn evaluate_type_cast(
             Ok(Value::Float(n))
         }
         CastTargetType::Timestamp => match value {
-            Value::DateTime { epoch_seconds, .. } => Ok(Value::Timestamp(*epoch_seconds as f64)),
+            Value::DateTime { epoch, .. } => Ok(Value::Timestamp(epoch.seconds() as f64)),
             _ => Err(CccError::eval(format!(
                 "cannot cast {} to timestamp",
                 value.type_name()
             ))),
         },
         CastTargetType::DateTime => match value {
-            Value::Timestamp(ts) => Ok(Value::DateTime {
-                epoch_seconds: *ts as i64,
-                offset_seconds: 0,
-            }),
+            Value::Timestamp(ts) => EpochSeconds::from_seconds(*ts as i64)
+                .map(|epoch| Value::DateTime {
+                    epoch,
+                    offset: UtcOffset::UTC,
+                })
+                .ok_or_else(|| CccError::eval("timestamp out of datetime range")),
             _ => Err(CccError::eval(format!(
                 "cannot cast {} to datetime",
                 value.type_name()

--- a/ccc/infrastructure/src/evaluator/unary_operation.rs
+++ b/ccc/infrastructure/src/evaluator/unary_operation.rs
@@ -9,7 +9,7 @@ pub(super) fn evaluate_unary(operator: &UnaryOperation, value: &Value) -> Result
             .map(Value::Integer)
             .ok_or_else(|| CccError::eval("integer negation overflow".to_string())),
         (UnaryOperation::Negate, Value::Float(n)) => Ok(Value::Float(-n)),
-        (UnaryOperation::Negate, Value::DurationTime(s)) => Ok(Value::DurationTime(-s)),
+        (UnaryOperation::Negate, Value::DurationTime(s)) => Ok(Value::DurationTime(-*s)),
         (UnaryOperation::Negate, v) => {
             Err(CccError::eval(format!("cannot negate a {}", v.type_name())))
         }

--- a/ccc/infrastructure/src/parser/datetime_literal.rs
+++ b/ccc/infrastructure/src/parser/datetime_literal.rs
@@ -1,5 +1,6 @@
 use domain::ast::Expression;
 use domain::error::CccError;
+use domain::time::{EpochSeconds, UtcOffset};
 
 use super::pest_based_parser::Rule;
 
@@ -33,15 +34,14 @@ pub(super) fn build_datetime_literal(
         .map_err(|e| CccError::parse(format!("invalid datetime second: {e}")))?;
 
     // Parse optional timezone offset
-    let offset_seconds = if source.len() > 19 {
+    let offset = if source.len() > 19 {
         parse_timezone_offset(&source[19..])?
     } else {
-        0 // default to UTC
+        UtcOffset::UTC
     };
 
-    // Validate via chrono: attempt to build a NaiveDateTime
-    if domain::calendar::calendar_to_epoch_seconds(year, month, day, hour, minute, second).is_none()
-    {
+    // Validate via chrono: attempt to build an instant
+    if EpochSeconds::from_calendar(year, month, day, hour, minute, second).is_none() {
         return Err(CccError::parse(format!(
             "invalid datetime: {year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}"
         )));
@@ -54,14 +54,14 @@ pub(super) fn build_datetime_literal(
         hour,
         minute,
         second,
-        offset_seconds,
+        offset,
     })
 }
 
 /// Parse a timezone suffix: `Z`, `+HH:MM`, `+HHMM`, or `+HH` (and `-` variants).
-fn parse_timezone_offset(tz: &str) -> Result<i32, CccError> {
+fn parse_timezone_offset(tz: &str) -> Result<UtcOffset, CccError> {
     if tz == "Z" {
-        return Ok(0);
+        return Ok(UtcOffset::UTC);
     }
     let sign: i32 = if tz.starts_with('+') { 1 } else { -1 };
     let rest = &tz[1..];
@@ -81,5 +81,10 @@ fn parse_timezone_offset(tz: &str) -> Result<i32, CccError> {
     } else {
         0
     };
-    Ok(sign * (hours * 3600 + minutes * 60))
+    let total_seconds = sign * (hours * 3600 + minutes * 60);
+    UtcOffset::from_seconds(total_seconds).ok_or_else(|| {
+        CccError::parse(format!(
+            "timezone offset out of range: {tz} (must be within ±24:00)"
+        ))
+    })
 }

--- a/ccc/infrastructure/src/parser/pest_based_parser_test.rs
+++ b/ccc/infrastructure/src/parser/pest_based_parser_test.rs
@@ -2,6 +2,7 @@
 mod tests {
     use domain::ast::{BinaryOperation, CastTargetType, Expression, UnaryOperation};
     use domain::interface::parser::CccParser;
+    use domain::time::UtcOffset;
 
     use crate::parser::PestBasedParser;
 
@@ -910,7 +911,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }
         );
     }
@@ -933,7 +934,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }
         );
     }
@@ -956,7 +957,7 @@ mod tests {
                 hour: 9,
                 minute: 0,
                 second: 0,
-                offset_seconds: 9 * 3600,
+                offset: UtcOffset::from_seconds(9 * 3600).unwrap(),
             }
         );
     }
@@ -979,7 +980,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: -5 * 3600,
+                offset: UtcOffset::from_seconds(-5 * 3600).unwrap(),
             }
         );
     }
@@ -1002,7 +1003,7 @@ mod tests {
                 hour: 9,
                 minute: 0,
                 second: 0,
-                offset_seconds: 9 * 3600,
+                offset: UtcOffset::from_seconds(9 * 3600).unwrap(),
             }
         );
     }
@@ -1049,7 +1050,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }
         );
     }

--- a/ccc/infrastructure/src/type_checker/ast_type_checker_test.rs
+++ b/ccc/infrastructure/src/type_checker/ast_type_checker_test.rs
@@ -4,6 +4,7 @@ mod tests {
         AbstractSyntaxTree, BinaryOperation, CastTargetType, Expression, UnaryOperation,
     };
     use domain::interface::type_checker::CccTypeChecker;
+    use domain::time::UtcOffset;
 
     use crate::type_checker::AstTypeChecker;
 
@@ -133,7 +134,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             })
             .is_ok()
         );
@@ -216,7 +217,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
             target_type: CastTargetType::Integer,
         };
@@ -334,7 +335,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
             right: Box::new(Expression::DurationTime {
                 hours: 1,
@@ -359,7 +360,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
             right: Box::new(Expression::DateTime {
                 year: 2026,
@@ -368,7 +369,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
         };
 
@@ -390,7 +391,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
             right: Box::new(Expression::DateTime {
                 year: 2026,
@@ -399,7 +400,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
         };
 
@@ -419,7 +420,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
             right: Box::new(Expression::Integer(2)),
         };
@@ -487,7 +488,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
         };
 
@@ -626,7 +627,7 @@ mod tests {
                 hour: 0,
                 minute: 0,
                 second: 0,
-                offset_seconds: 0,
+                offset: UtcOffset::from_seconds(0).unwrap(),
             }),
             target_type: CastTargetType::Timestamp,
         };


### PR DESCRIPTION
## Background

時刻関連の値が素の整数のまま全レイヤーを流れていた。

- 期間は `i64`(秒)
- 日時は `epoch_seconds: i64` + `offset_seconds: i32`

このため2種類の「秒」(時点と期間)を型レベルで区別できず、
範囲検証は値の利用側に散らばっていた。

実害もあった。表示時の `FixedOffset::east_opt(...).expect(...)` は
±24h を超えるオフセットで panic する。パース時に検証されないため、
`2026-01-01T00:00:00+30:00` のような入力が評価まで通り、表示で落ちる経路が存在した。

refactor.md の「バリューオブジェクトを積極活用する」「DDDの型でロジックの正しさを
表現する手法を取り入れる(アーキテクチャは変えない)」に基づく改善である。

## Approach

`domain::time` に3つの newtype を導入し、不変条件をコンストラクタに集約した。

- `DurationSeconds` — 符号付きの時間幅。時点(`EpochSeconds`)と型レベルで区別される
- `EpochSeconds` — chrono で表現可能なことを構築時に保証する時点
- `UtcOffset` — `FixedOffset` の受理範囲(±24h)を構築時に保証するオフセット

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: 不変条件を持つ箇所のみ newtype 化(採用) | 検証が構築時の1箇所に集約。表示側の再検証・panic 経路が消える | 構築サイトに `from_seconds(...)` のラップが必要 |
| B: 年月日時分秒の各コンポーネントまで全て newtype 化 | 型安全性は最大 | 過剰な複雑化。refactor.md の「複雑すぎる型を避ける」に反する |
| C: 現状維持 + バリデーション関数の追加 | 差分最小 | 「検証済みかどうか」が型に現れず、呼び忘れを防げない |

### 採用理由

不正な状態を型で表現不可能にしつつ(Make Illegal States Unrepresentable)、
型の複雑さは「秒の意味の区別」と「範囲保証」に限定した。
ライフタイムや generics は使わず、全て `Copy` な薄い newtype である。

## What Changed

### domain: time モジュールの新設

- `time/duration_seconds.rs` - 期間。`Add/Sub/Neg/Mul<i64>/Div<i64>` で期間演算を表現
- `time/epoch_seconds.rs` - 時点。`from_calendar`/`to_calendar`(旧 calendar 関数のロジックを吸収)、`checked_add`/`checked_sub`/`duration_since`
- `time/utc_offset.rs` - オフセット。`from_seconds` は範囲外で `None`
- `value.rs` - `Value::DurationTime(DurationSeconds)`、`Value::DateTime { epoch, offset }` に変更
- `ast.rs` - `Expression::DateTime` の `offset_seconds: i32` を検証済み `UtcOffset` に変更
- `calendar.rs` - epoch 変換ロジックは `EpochSeconds` へ移動し、`days_in_month` のみ残置

### infrastructure: 検証の境界への移動

- `parser/datetime_literal.rs` - タイムゾーンオフセットをパース時に検証。範囲外は parse error になり、**表示時 panic の経路を塞いだ**
- `evaluator/binary_datetime.rs` - datetime±duration が chrono の範囲を出る場合、panic 予約ではなく eval error を返す
- `evaluator/type_cast.rs` - timestamp→datetime キャストも同様に範囲検証
- `builtin/` - コンストラクタ・時刻関数・統計関数を newtype 経由の構築に変更
- `builtin_helpers/conversion.rs` - `Value::type_name()` と重複していた `value_type_name` を削除

## Tradeoffs and Limitations

- **構築サイトの冗長化**: テストを含め `DurationSeconds::from_seconds(3600)` のようなラップが必要になった。テスト側の記述量は次のPR(Fixture導入)で削減する
- **エラーメッセージの変化(極端系のみ)**: chrono 範囲外の datetime 演算は従来「表示時 panic」だったが、`eval error: datetime out of range` を返すようになった。通常の入力では観測可能な振る舞いは変わらない
- **`Timestamp(f64)` は newtype 化していない**: サブ秒精度の f64 で不変条件を持たないため、今回のスコープ外とした

## Testing

既存の380テストを回帰テストとして利用し、全件パスを確認した。
テストの変更は構築式のラップ(`DurationSeconds::from_seconds` 等)と
フィールド名変更(`epoch_seconds` → `epoch`)のみで、期待値は一切変えていない。
これにより観測可能な振る舞いの保存を担保している。

- cargo test: 380 passed / 0 failed
- cargo clippy --workspace -- -D warnings: クリーン
- cargo fmt --check: クリーン
- 全ロジックファイル80行以下を維持

## Review Guide

1. まず `ccc/domain/src/time/` の3ファイルを読んでください — 不変条件の定義が今回の核です
2. 次に `ccc/infrastructure/src/parser/datetime_literal.rs` の `parse_timezone_offset` — 検証がパース境界に移った箇所です
3. `ccc/infrastructure/src/evaluator/binary_datetime.rs` — checked 演算によるエラー化の方針を確認してください
4. テスト diff は機械的なラップのみです(期待値の変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)