### PR TITLE
Add per-crate README guides

### DIFF
--- a/ccc/domain/README.md
+++ b/ccc/domain/README.md
@@ -1,0 +1,84 @@
+# domain
+
+## 概要
+
+ccc の中核となる型を定義する crate です。
+
+AST・計算値・静的型・エラー・時刻のバリューオブジェクトを提供します。
+
+他の crate に依存しません。
+依存グラフの最下層に位置します。
+
+## 背景
+
+電卓のロジックは「式の構造」と「値の意味」に強く依存します。
+
+これらの定義が各レイヤーに散らばると、
+仕様変更のたびに全体を追う必要が生じます。
+
+そこで、意味の定義をこの crate に集約しています。
+
+## 目的
+
+- 式・値・型・エラーの定義を1箇所にまとめる
+- 不正な状態を型で表現できなくする
+- パーサーや評価器の実装詳細から、意味の定義を切り離す
+
+## 手法
+
+### インターフェース定義 (依存性逆転)
+
+`interface/` に `CccParser` / `CccTypeChecker` / `CccEvaluator` を定義します。
+
+実装は infrastructure crate が提供します。
+上位レイヤーはこの trait にのみ依存します。
+
+### バリューオブジェクト
+
+`time/` に3つの newtype を定義します。
+
+- `DurationSeconds` — 符号付きの時間幅
+- `EpochSeconds` — chrono で表現可能なことを保証する時点
+- `UtcOffset` — 表示可能な範囲(±24h)を保証するタイムゾーンオフセット
+
+検証はコンストラクタで行います。
+構築できた値は、以降の検証なしで安全に使えます。
+
+### 主要モジュール
+
+| モジュール | 内容 |
+|---|---|
+| `ast` | 式の構造 (`Expression`, `BinaryOperation` など) |
+| `value` | 計算結果 (`Value`) と表示 (`value_display`) |
+| `static_type` | 型検査で使う静的型 (`StaticType`) |
+| `time` | 時刻のバリューオブジェクト |
+| `error` | エラー型 (`CccError`) と発生位置 |
+| `calendar` | 暦のユーティリティ |
+| `interface` | パーサー・型検査器・評価器の trait |
+
+## 処理の事例
+
+`1 + 2 * 3` という式は、次の AST で表現されます。
+
+```rust
+use domain::ast::{BinaryOperation, Expression};
+
+Expression::BinaryOperation {
+    operator: BinaryOperation::Add,
+    left: Box::new(Expression::Integer(1)),
+    right: Box::new(Expression::BinaryOperation {
+        operator: BinaryOperation::Multiply,
+        left: Box::new(Expression::Integer(2)),
+        right: Box::new(Expression::Integer(3)),
+    }),
+}
+```
+
+時刻のバリューオブジェクトは、範囲外の値を構築段階で拒否します。
+
+```rust
+use domain::time::UtcOffset;
+
+let tokyo = UtcOffset::from_seconds(9 * 3600); // Some(UtcOffset)
+let invalid = UtcOffset::from_seconds(30 * 3600); // None (±24h を超える)
+```

--- a/ccc/infrastructure/README.md
+++ b/ccc/infrastructure/README.md
@@ -1,0 +1,85 @@
+# infrastructure
+
+## 概要
+
+domain の trait を実装する crate です。
+
+パーサー・型検査器・評価器の3つの実装を提供します。
+
+## 背景
+
+「式をどう解析するか」「どう評価するか」は実装の詳細です。
+
+パーサーライブラリの変更や評価戦略の変更が、
+上位レイヤーへ波及しない構造が必要でした。
+
+そこで、実装をこの crate に隔離し、
+domain の trait 経由でのみ公開しています。
+
+## 目的
+
+- `CccParser` / `CccTypeChecker` / `CccEvaluator` の実装を提供する
+- 実装詳細 (pest、評価アルゴリズム) を外部へ漏らさない
+- 文法規則・型規則・評価規則を、それぞれ独立に変更可能にする
+
+## 手法
+
+### parser
+
+pest (PEG パーサー) を利用します。
+
+文法は `src/parser/grammar.pest` に宣言的に記述します。
+
+モジュールは文法規則ごとに分かれています。
+たとえば duration リテラルの仕様変更は `duration_literal.rs` だけを読めば足ります。
+
+### type_checker
+
+評価前に式の型を推論し、不正な組み合わせを拒否します。
+
+型規則は表として読めるよう、規則の種類ごとにモジュールを分けています
+(`binary_rule` / `cast_rule` / `function_rule` / `argument_rule`)。
+
+### evaluator
+
+AST を再帰的に評価します。
+
+二項演算は値の型ペアでディスパッチし、
+数値 (`binary_numeric`)・期間 (`binary_duration`)・日時 (`binary_datetime`) に分かれます。
+
+組み込み関数は `builtin/` 配下で分類ごとに実装します
+(math / list / statistics / extremum / constructor / time)。
+
+### テスト
+
+`test_fixture` の式ビルダーで AST を構築します。
+
+`add(int(1), mul(int(2), int(3)))` は `1 + 2*3` を表します。
+
+テストは公開 API (trait メソッド) のみを対象とします。
+
+## 処理の事例
+
+`"1 + 2 * 3"` は次のパイプラインで処理されます。
+
+```text
+input:  "1 + 2 * 3"
+          │
+          ▼  PestBasedParser::parse
+        AST: Add(1, Multiply(2, 3))
+          │
+          ▼  AstTypeChecker::check
+        OK: Integer 同士の演算
+          │
+          ▼  AstEvaluator::evaluate
+        Value::Integer(7)
+```
+
+型検査は不正な式を評価前に弾きます。
+
+```text
+input:  "1 + [2]"
+          │
+          ▼  AstTypeChecker::check
+        Err: unsupported operation: integer + list[integer]
+```

--- a/ccc/presentation/README.md
+++ b/ccc/presentation/README.md
@@ -1,0 +1,78 @@
+# presentation
+
+## 概要
+
+CLI のエントリポイントとなる crate です。
+
+バイナリ `ccc` を提供します。
+
+引数の解釈、入力モードの判定、依存の組み立て、出力を担当します。
+
+## 背景
+
+ユーザーとの接点 (CLI 引数、stdin/stdout、終了コード) は
+計算ロジックとは変更理由が異なります。
+
+ここを最外殻として分離することで、
+内側のレイヤーは入出力を知らずに済みます。
+
+## 目的
+
+- CLI 引数を解釈し、入力モードを決定する
+- infrastructure の実装を usecase に注入する (composition root)
+- 計算結果とエラーを整形して出力し、終了コードを返す
+
+## 手法
+
+### 入力モードの判定
+
+`input_mode` が引数と stdin の状態からモードを決めます。
+
+| モード | 起動例 |
+|---|---|
+| `Expression` | `ccc "1 + 2"` |
+| `Repl` | `ccc repl` |
+| `Pipe` | `echo "1 + 2" \| ccc` |
+| `PipeWithArgs` | `echo "1 + 2" \| ccc "* 3"` |
+| `ShowBuiltin` | `ccc show builtin` |
+
+### 依存の組み立て
+
+`main.rs` が composition root です。
+
+`PestBasedParser` / `AstTypeChecker` / `AstEvaluator` を生成し、
+ユースケースに注入します。
+
+実装の選択がここに集約されるため、
+差し替えは main の1箇所の変更で済みます。
+
+### 組み込み関数リファレンス
+
+`builtin_reference.rs` に関数一覧を宣言的なデータとして持ちます。
+
+`show_builtin.rs` はそれを整形して表示するだけです。
+
+### テスト
+
+`tests/cli/` に統合テストがあります。
+
+実際のバイナリを起動し、stdout・stderr・終了コードを検証します。
+
+## 処理の事例
+
+```bash
+$ ccc "2 + 3 * 4"
+14
+
+$ echo "10 - 3" | ccc
+7
+
+$ echo "5" | ccc + 1
+6
+
+$ ccc "*3"
+  *3
+  ^
+  error: parse error: expected number, function call, list, or '('
+# 終了コード 1
+```

--- a/ccc/usecase/README.md
+++ b/ccc/usecase/README.md
@@ -1,0 +1,69 @@
+# usecase
+
+## 概要
+
+アプリケーションの操作単位 (ユースケース) を定義する crate です。
+
+「式を計算する」「パイプ入力を処理する」「REPL を回す」を提供します。
+
+## 背景
+
+CLI には複数の入力モードがあります。
+
+引数で式を受け取るモード、stdin から行を読むモード、対話モードです。
+
+モードごとの制御フローを presentation に書くと main が肥大化します。
+かといって infrastructure に書くと、実装詳細と業務フローが混ざります。
+
+そこで、フローだけをこの crate に切り出しています。
+
+## 目的
+
+- 「parse → type check → evaluate」の手順を1箇所で定義する
+- 入力モードごとの制御フローを部品化する
+- 具体的な実装ではなく domain の trait に依存する (依存性逆転)
+
+## 手法
+
+ユースケースはジェネリクスで trait 実装を受け取ります。
+
+```rust
+pub struct CalculateMathExpressionUsecase<P, T, E> {
+    parser: P,
+    type_checker: T,
+    evaluator: E,
+}
+```
+
+どのパーサー・評価器を使うかは呼び出し側 (presentation) が注入します。
+この crate は infrastructure を知りません。
+
+### 主要モジュール
+
+| モジュール | 内容 |
+|---|---|
+| `calculate_math_expression` | parse → type_check → evaluate の直列実行 |
+| `evaluate_piped_input` | stdin の行ごとの評価。引数サフィックスの付加にも対応 |
+| `interactive_repl` | 対話ループ |
+| `format_error` | エラー位置をキャレット (`^`) で指すメッセージ整形 |
+
+## 処理の事例
+
+式の計算は3ステップの直列です。
+途中で失敗したら、そこで `Err` を返します (鉄道志向)。
+
+```rust
+pub fn execute(&self, input: &str) -> Result<Value, CccError> {
+    let ast = self.parser.parse(input)?;
+    self.type_checker.check(&ast)?;
+    self.evaluator.evaluate(&ast)
+}
+```
+
+エラー整形は発生位置をキャレットで示します。
+
+```text
+  *3
+  ^
+  error: parse error: expected number, function call, list, or '('
+```


### PR DESCRIPTION
## Background

各 crate には README がなく、レイヤーの責務と設計判断はコードを読んで推測するしかなかった。

直前の3つのリファクタPR (#35 モジュール分割、#36 バリューオブジェクト、#37 テスト改良) で
構造が整理されたため、その設計意図を文書として固定するタイミングである。

refactor.md の「crateごとに、READMEを作る。概要、背景、目的、手法、処理の事例を紹介する」に基づく。

## Approach

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: crate ごとの README.md(採用) | crate を開いた瞬間に責務が分かる。GitHub 上でディレクトリ閲覧時に自動表示される | コード変更時に文書の追従が必要 |
| B: rustdoc (`//!` モジュールコメント) のみ | コードと文書が同居し乖離しにくい | 概要・背景のような散文に向かない。cargo doc を開かないと読めない |
| C: docs/ 配下に集約 | 1箇所で全体を読める | crate との距離が遠く、更新が忘れられやすい |

### 採用理由

「このディレクトリは何か」に答える文書は、そのディレクトリに置くのが最も発見されやすい。
refactor.md の指定形式(概要・背景・目的・手法・処理の事例)にも README が適する。

## What Changed

4つの README を新規作成した。コード変更はない。

- `ccc/domain/README.md` - 型定義の集約と依存性逆転の説明。time バリューオブジェクトの不変条件と、構築時検証の事例
- `ccc/infrastructure/README.md` - parser / type_checker / evaluator の実装方針。式が処理されるパイプラインの図解
- `ccc/usecase/README.md` - 鉄道志向の計算フローと入力モード別ユースケース。ジェネリクスによる注入の説明
- `ccc/presentation/README.md` - 入力モード判定表、composition root としての main、CLI の実行例

文体は refactor.md の指定どおり、1文を短く、改行を多めにしている。

## Tradeoffs and Limitations

- **文書の保守コスト**: コード変更時に README の追従が必要になる。各 README は詳細仕様ではなく安定した設計判断(レイヤー責務・依存方向)を中心に書くことで陳腐化リスクを抑えた
- **日本語で記述**: ルート README は英語だが、crate README は開発者向けガイドとして refactor.md と同じ日本語にした

## Testing

文書のみの変更だが、記載した CLI 実行例・エラーメッセージは全て実バイナリの出力と照合した。

検証中に既知でない挙動を1件発見した: `ccc "1 + * 2"` が parse error にならず `1` を返す
(pest 文法が EOI でアンカーされておらず、先頭の有効な前置部分だけが解釈される)。
本PRのスコープ外のため修正していない。別 Issue として扱うのが妥当。

## Review Guide

1. まず `ccc/domain/README.md` — 形式(概要・背景・目的・手法・事例)の代表です
2. `ccc/infrastructure/README.md` のパイプライン図が分かりやすいか確認してください
3. 各 README の「処理の事例」が実際の挙動と一致しているかは検証済みです

🤖 Generated with [Claude Code](https://claude.com/claude-code)