### PR TITLE
Anchor grammar with SOI/EOI to reject invalid trailing input

### DIFF
--- a/ccc/infrastructure/src/parser/error_message.rs
+++ b/ccc/infrastructure/src/parser/error_message.rs
@@ -29,6 +29,8 @@ fn humanize_pest_error(variant: &pest::error::ErrorVariant<Rule>) -> String {
 
 fn humanize_rule(rule: &Rule) -> &'static str {
     match rule {
+        Rule::program => "expression",
+        Rule::EOI => "end of input",
         Rule::expression => "expression",
         Rule::term => "term",
         Rule::power => "expression",

--- a/ccc/infrastructure/src/parser/grammar.pest
+++ b/ccc/infrastructure/src/parser/grammar.pest
@@ -1,3 +1,6 @@
+// Root rule: anchored to both ends so partially-valid input is rejected.
+program = { SOI ~ expression ~ EOI }
+
 expression = { term ~ (additive_operator ~ term)* }
 
 term = { power ~ (multiplicative_operator ~ power)* }

--- a/ccc/infrastructure/src/parser/pest_based_parser.rs
+++ b/ccc/infrastructure/src/parser/pest_based_parser.rs
@@ -23,12 +23,16 @@ pub struct PestBasedParser;
 
 impl CccParser for PestBasedParser {
     fn parse(&self, input: &str) -> Result<AbstractSyntaxTree, CccError> {
+        // Rule::program is anchored with SOI/EOI, so input with a valid
+        // prefix but invalid trailing content fails here instead of being
+        // silently truncated (see issue #39).
         let pairs =
-            ExpressionParser::parse(Rule::expression, input).map_err(|e| to_parse_error(&e))?;
+            ExpressionParser::parse(Rule::program, input).map_err(|e| to_parse_error(&e))?;
 
         let pair = pairs
             .into_iter()
             .next()
+            .and_then(|program| program.into_inner().next())
             .ok_or_else(|| CccError::parse("empty input".to_string()))?;
 
         let expression = build_expression(pair)?;

--- a/ccc/infrastructure/src/parser/pest_based_parser_test/error.rs
+++ b/ccc/infrastructure/src/parser/pest_based_parser_test/error.rs
@@ -1,4 +1,3 @@
-use domain::ast::Expression;
 use domain::interface::parser::CccParser;
 
 use crate::parser::PestBasedParser;
@@ -41,15 +40,54 @@ fn parse_unclosed_paren_is_error() {
     assert!(result.is_err());
 }
 
+// --- Trailing input rejection (issue #39) ---
+// The grammar is anchored with SOI/EOI, so a valid prefix followed by
+// invalid trailing content must fail instead of being silently truncated.
+
 #[test]
-fn parse_trailing_operator_ignores_trailing() {
-    // Arrange: Pest grammar matches "1" as expression; trailing "+" is not consumed.
+fn parse_trailing_operator_is_error() {
+    // Arrange
     let parser = PestBasedParser;
 
     // Act
     let result = parser.parse("1 +");
 
     // Assert
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap().expression, Expression::Integer(1));
+    assert!(result.is_err());
+}
+
+#[test]
+fn parse_valid_prefix_with_invalid_operator_sequence_is_error() {
+    // Arrange
+    let parser = PestBasedParser;
+
+    // Act
+    let result = parser.parse("1 + * 2");
+
+    // Assert
+    assert!(result.is_err());
+}
+
+#[test]
+fn parse_two_expressions_without_operator_is_error() {
+    // Arrange
+    let parser = PestBasedParser;
+
+    // Act
+    let result = parser.parse("1 2");
+
+    // Assert
+    assert!(result.is_err());
+}
+
+#[test]
+fn parse_unmatched_closing_paren_is_error() {
+    // Arrange
+    let parser = PestBasedParser;
+
+    // Act
+    let result = parser.parse("1 + 2)");
+
+    // Assert
+    assert!(result.is_err());
 }

--- a/ccc/presentation/tests/cli/error_reporting.rs
+++ b/ccc/presentation/tests/cli/error_reporting.rs
@@ -42,6 +42,21 @@ fn invalid_expression_fails() {
 }
 
 #[test]
+fn valid_prefix_with_invalid_trailing_input_fails() {
+    // Arrange: "1" alone is valid, but the trailing "+ * 2" must not be
+    // silently dropped (regression test for issue #39)
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("1 + * 2").assert();
+
+    // Assert
+    result
+        .failure()
+        .stderr(predicate::str::contains("parse error"));
+}
+
+#[test]
 fn mixed_type_list_fails() {
     // Arrange
     let mut cmd = ccc();


### PR DESCRIPTION
## Background

`ccc "1 + * 2"` が parse error にならず `1` を返し、終了コード 0 で成功していた。

pest は文法のルート規則に入力全体の消費を要求しない。
ルート規則 `expression` が `term ~ (additive_operator ~ term)*` であるため、
繰り返し部が0回マッチして先頭の `1` だけで「成功」し、残りは黙って捨てられていた。

電卓として致命的な性質である: 無効な入力が誤った答えとして返り、
ユーザーは気づく手段がない。#38 の README 事例検証中に発見した。

Closes #39

## Approach

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: アンカー付きルート規則 `program = SOI ~ expression ~ EOI` を追加(採用) | 文法自体が「入力全体が1つの式である」ことを宣言する。再帰利用される `expression` は無変更 | Rule が2つ増え、humanize の対応が必要 |
| B: `expression` 規則自体に EOI を埋め込む | 規則が増えない | `expression` は括弧・引数・リスト内で再帰利用されるため、そこでも EOI を要求してしまい文法が壊れる |
| C: パース後に残余入力を Rust 側でチェック | 文法無変更 | 「入力全体が式である」という仕様が文法の外に漏れ、宣言的でなくなる |

### 採用理由

入力全体の消費は文法の仕様であり、文法ファイルに宣言的に書くのが正しい置き場所である。
pest の標準的なイディオム(SOI/EOI アンカー)でもある。

## What Changed

### 文法のアンカー

- `grammar.pest` - ルート規則 `program = { SOI ~ expression ~ EOI }` を追加。既存規則は無変更

### パーサーのエントリポイント変更

- `pest_based_parser.rs` - `Rule::program` でパースし、内側の `expression` ペアから AST を構築。issue 参照のコメントを付記
- `error_message.rs` - 新しい `Rule::program` / `Rule::EOI` の人間向け表現を追加(`EOI` → "end of input")

### 回帰テスト

- `pest_based_parser_test/error.rs` - 旧挙動(末尾の無視)を仕様として固定していた `parse_trailing_operator_ignores_trailing` を削除し、末尾演算子・演算子連続・式の並置・閉じ括弧過多の4ケースをエラーと検証するテストに置換
- `tests/cli/error_reporting.rs` - `ccc "1 + * 2"` が失敗し parse error を表示することを CLI 統合レベルで検証

## Tradeoffs and Limitations

- **破壊的変更(意図的)**: これまで「成功」していた `1 +` や `1 2` のような入力はエラーになる。これはバグの修正そのものであり、正しい式の挙動は一切変わらない
- **エラーメッセージの変化**: 末尾が不正な入力では "expected end of input or ..." を含むメッセージになる。位置情報(キャレット)は最初に解釈できないトークンを指す

## Testing

修正前にバグを再現するテストを書き、修正後に全件パスすることを確認した。

```text
$ ccc "1 + * 2"
  1 + * 2
      ^
  error: parse error: expected number, function call, list, or '('
(exit code 1)
```

- cargo test: 360 passed / 0 failed (回帰テスト4件 + CLI 1件を追加)
- 正常系の全テスト(四則演算・関数・リスト・時刻・REPL・パイプ)が無変更でパスし、有効な式の挙動が保存されていることを確認
- cargo clippy --workspace --all-targets -- -D warnings / cargo fmt --check: クリーン

## Review Guide

1. まず `ccc/infrastructure/src/parser/grammar.pest` — 3行の追加が修正の本体です
2. 次に `pest_based_parser.rs` — エントリポイントが `Rule::program` になり、内側の expression を取り出す流れを確認してください
3. `pest_based_parser_test/error.rs` — 削除した旧テストが「バグの固定」だったことは diff から判断できます

🤖 Generated with [Claude Code](https://claude.com/claude-code)