### PR TITLE
Allow hyphen-leading expressions as CLI arguments

### DIFF
--- a/ccc/presentation/src/cli.rs
+++ b/ccc/presentation/src/cli.rs
@@ -7,7 +7,9 @@ pub struct Cli {
     pub command: Option<Command>,
 
     /// Expression to evaluate (e.g. 1 + 2)
-    #[arg(trailing_var_arg = true)]
+    // CONSTRAINT: clap は先頭ハイフンの位置引数を未知のフラグとして拒否するため、
+    // 単項マイナスで始まる式 (例: "-5 + 3") には allow_hyphen_values が必要
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub expression: Vec<String>,
 }
 

--- a/ccc/presentation/tests/cli/arithmetic.rs
+++ b/ccc/presentation/tests/cli/arithmetic.rs
@@ -112,7 +112,7 @@ fn evaluate_float() {
 
 #[test]
 fn evaluate_negative_unary() {
-    // Arrange: leading "-" is interpreted as a flag by clap, so use "--" separator
+    // Arrange: the "--" separator remains supported alongside bare hyphen expressions
     let mut cmd = ccc();
 
     // Act
@@ -120,6 +120,42 @@ fn evaluate_negative_unary() {
 
     // Assert
     result.success().stdout("-2\n");
+}
+
+#[test]
+fn evaluate_negative_unary_without_separator() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("-5 + 3").assert();
+
+    // Assert
+    result.success().stdout("-2\n");
+}
+
+#[test]
+fn evaluate_double_negate_without_separator() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("--5").assert();
+
+    // Assert
+    result.success().stdout("5\n");
+}
+
+#[test]
+fn evaluate_negative_duration_without_separator() {
+    // Arrange
+    let mut cmd = ccc();
+
+    // Act
+    let result = cmd.arg("-1:30:00").assert();
+
+    // Assert
+    result.success().stdout("-1:30:00\n");
 }
 
 #[test]


### PR DESCRIPTION
## 概要

ドキュメントに記載されている `ccc "-5 + 3"` などのハイフンで始まる式が CLI 引数として拒否されるバグを修正する。

## 背景

docs/example.md の Unary Operators / Duration Arithmetic セクションには `ccc "-5 + 3"`、`ccc "--5"`、`ccc "-1:30:00"` が動作例として記載されている。しかし実際に実行すると clap が `error: unexpected argument '-5' found` を返し、ドキュメントと実挙動が乖離していた。

## 課題

clap は先頭がハイフンの位置引数を未知のフラグとして解釈するため、単項マイナスで始まる式・負の duration がすべて評価不能だった。回避には `ccc -- "-5 + 3"` と `--` セパレータが必要だが、ドキュメントには一切記載がなく、ユーザーが知る手段がない。

## 目標

### 必須項目

- ドキュメント記載の `ccc "-5 + 3"` / `ccc "--5"` / `ccc "-1:30:00"` がそのまま動作する
- `--help` / `--version` / `repl` / `show builtin` / `--` セパレータの既存挙動を壊さない

### 範囲外

- パイプモード・REPL の挙動変更(元より正常)
- 式評価器側の変更

## 採用手法

式引数に clap の `allow_hyphen_values = true` を付与する。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: `allow_hyphen_values = true`(採用) | 1 行で修正でき、ドキュメントの全例がそのまま動く | 式引数の位置に置かれたフラグのタイポ(例: `ccc --helo`)がフラグエラーではなくパースエラーになる |
| B: ドキュメントに `--` セパレータを追記 | コード変更なし | UX が悪いまま。ドキュメント例をすべて書き換える必要がある |

### 採用理由

計算機 CLI にとって負数式は一級の入力であり、ユーザーに `--` の知識を要求するのは不合理。`--help` / `--version` はフラグとして先に解決されるため既存インターフェースへの影響はなく、検証で全サブコマンド・フラグの動作維持を確認済み。

## 変更箇所

- `ccc/presentation/src/cli.rs`: 式引数に `allow_hyphen_values = true` を付与
- `ccc/presentation/tests/cli/arithmetic.rs`: `--` セパレータなしの負数式・二重否定・負 duration の CLI テストを 3 件追加

## 妥協と制限

- **フラグタイポの診断低下**: `ccc --helo` のような誤入力は「unknown flag」ではなくパースエラーとして報告される。計算機 CLI ではフラグより式入力が支配的なため受容した。

## 検証方法

- `cargo test --release` 全 363 テストパス(追加 3 件含む)
- `cargo clippy --all-targets` 警告なし
- 手動確認: `-5 + 3` → `-2`、`--5` → `5`、`-1:30:00` → `-1:30:00`、`--version` / `--help` / `repl` / `show builtin` / `-- "-5+3"` すべて正常

## 確認事項

- ⚠️ フラグ誤入力時のエラーメッセージがパースエラーに変わる点を許容できるか

## 参考文献

- docs/example.md (Unary Operators / Duration Arithmetic セクション)
