### PR TITLE
Reject integer overflow instead of silently wrapping

### DIFF
--- a/ccc/infrastructure/src/evaluator/ast_evaluator_test/arithmetic.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator_test/arithmetic.rs
@@ -176,6 +176,53 @@ fn modulo_floats() {
     }
 }
 
+// --- Integer overflow ---
+
+#[test]
+fn add_overflow_reports_error() {
+    // Arrange
+    let expression = add(int(i64::MAX), int(1));
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval(format!("integer overflow: {} + 1", i64::MAX))
+    );
+}
+
+#[test]
+fn subtract_overflow_reports_error() {
+    // Arrange
+    let expression = sub(int(i64::MIN), int(1));
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval(format!("integer overflow: {} - 1", i64::MIN))
+    );
+}
+
+#[test]
+fn multiply_overflow_reports_error() {
+    // Arrange
+    let expression = mul(int(i64::MAX), int(2));
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval(format!("integer overflow: {} * 2", i64::MAX))
+    );
+}
+
 // --- Nested expressions ---
 
 #[test]

--- a/ccc/infrastructure/src/evaluator/ast_evaluator_test/power_unary.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator_test/power_unary.rs
@@ -43,6 +43,21 @@ fn power_float_base() {
     assert_eq!(result.unwrap(), Value::Float(8.0));
 }
 
+#[test]
+fn power_overflow_reports_error() {
+    // Arrange: 2 ** 64 exceeds i64::MAX
+    let expression = pow(int(2), int(64));
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("integer overflow: 2 ** 64".to_string())
+    );
+}
+
 // --- Unary operators ---
 
 #[test]

--- a/ccc/infrastructure/src/evaluator/binary_numeric.rs
+++ b/ccc/infrastructure/src/evaluator/binary_numeric.rs
@@ -2,15 +2,43 @@ use domain::ast::BinaryOperation;
 use domain::error::CccError;
 use domain::value::Value;
 
+// Wrapping would silently return a wrong value (e.g. i64::MAX + 1 → i64::MIN),
+// so every integer operation that can overflow reports an eval error instead,
+// mirroring the checked unary negation and datetime range checks.
+fn integer_overflow_error(left: i64, operator_symbol: &str, right: i64) -> CccError {
+    CccError::eval(format!(
+        "integer overflow: {left} {operator_symbol} {right}"
+    ))
+}
+
+fn checked_integer(
+    checked_result: Option<i64>,
+    left: i64,
+    operator_symbol: &str,
+    right: i64,
+) -> Result<Value, CccError> {
+    checked_result
+        .map(Value::Integer)
+        .ok_or_else(|| integer_overflow_error(left, operator_symbol, right))
+}
+
+fn evaluate_integer_power(left: i64, right: i64) -> Result<Value, CccError> {
+    if right >= 0 && right <= u32::MAX as i64 {
+        checked_integer(left.checked_pow(right as u32), left, "**", right)
+    } else {
+        Ok(Value::Float((left as f64).powf(right as f64)))
+    }
+}
+
 pub(super) fn evaluate_binary_integer(
     operator: &BinaryOperation,
     left: i64,
     right: i64,
 ) -> Result<Value, CccError> {
     match operator {
-        BinaryOperation::Add => Ok(Value::Integer(left + right)),
-        BinaryOperation::Subtract => Ok(Value::Integer(left - right)),
-        BinaryOperation::Multiply => Ok(Value::Integer(left * right)),
+        BinaryOperation::Add => checked_integer(left.checked_add(right), left, "+", right),
+        BinaryOperation::Subtract => checked_integer(left.checked_sub(right), left, "-", right),
+        BinaryOperation::Multiply => checked_integer(left.checked_mul(right), left, "*", right),
         BinaryOperation::Divide => {
             if right == 0 {
                 return Err(CccError::eval(format!(
@@ -30,13 +58,7 @@ pub(super) fn evaluate_binary_integer(
             }
             Ok(Value::Integer(left % right))
         }
-        BinaryOperation::Power => {
-            if right >= 0 && right <= u32::MAX as i64 {
-                Ok(Value::Integer(left.pow(right as u32)))
-            } else {
-                Ok(Value::Float((left as f64).powf(right as f64)))
-            }
-        }
+        BinaryOperation::Power => evaluate_integer_power(left, right),
     }
 }
 

--- a/docs/spec/interpreter.md
+++ b/docs/spec/interpreter.md
@@ -144,7 +144,7 @@ This is stored as:
 The evaluator produces `CccError::Eval` for runtime errors:
 
 - Division/modulo by zero
-- Integer negation overflow
+- Integer overflow (addition, subtraction, multiplication, power, negation)
 - Invalid datetime components
 - Unknown function names
 - Argument count mismatches


### PR DESCRIPTION
## 概要

整数二項演算のオーバーフローが release ビルドで黙って wrap し、誤った計算結果を返すバグを修正する。オーバーフロー時は eval エラーとして報告する。

## 背景

バグハントの一環で境界値を検査したところ、`ccc "9223372036854775807 + 1"` が `-9223372036854775808`、`ccc "2 ** 64"` が `0` を返すことを発見した。電卓として「黙って間違った答えを返す」のは最も深刻な故障モードである。

## 課題

`binary_numeric.rs` の整数加減乗と累乗が未チェックの演算子(`+`/`-`/`*`/`pow`)を使っており、release ビルドでは wrap する。一方で単項否定(`checked_neg` + `integer negation overflow` エラー)と datetime 演算(`datetime out of range` エラー)は既に検査済みであり、二項整数演算だけが検査から漏れた非一貫な状態だった。docs/spec/interpreter.md のエラー一覧にも negation のみが記載されていた。

## 目標

### 必須項目

- 整数の加算・減算・乗算・累乗のオーバーフローが `integer overflow: <left> <op> <right>` の eval エラーになる
- オーバーフローしない演算の結果・型昇格規則(除算の Float 昇格、負指数の Float 昇格)は不変
- spec ドキュメントのエラー一覧を新挙動に一致させる

### 範囲外

- duration スケーリング(`DurationSeconds * i64`)や list 集約(`sum`/`prod`)のオーバーフロー — 同クラスの問題だが別 Issue として扱う
- float の inf/NaN 取り扱い

## 採用手法

`checked_add` / `checked_sub` / `checked_mul` / `checked_pow` に置き換え、`None` を共通ヘルパー `checked_integer` で eval エラーへ変換する。エラーメッセージは既存の `division by zero: {left} / {right}` と同じ形に揃えた。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: checked 演算 + eval エラー(採用) | 既存の negation / datetime のエラー方針と一貫。誤答を返さない | 巨大数の計算が不可能になる |
| B: オーバーフロー時に f64 へ昇格 | 計算は継続できる | 精度が黙って落ちる(53bit 超で誤差)。型昇格規則が複雑化 |
| C: 任意精度整数 (bigint) 導入 | 常に正確 | 依存追加と型システム全体の再設計が必要。本 PR の範囲を大きく超える |

### 採用理由

domain 層の既存方針(checked negation・EpochSeconds の範囲検査)が「範囲外は誤魔化さずエラー」を既に選択している。二項演算だけを昇格や wrap にするのは非一貫であり、最小差分で一貫性を回復する A を採用した。

## 変更箇所

- `ccc/infrastructure/src/evaluator/binary_numeric.rs`: 整数 add/sub/mul/pow を checked 演算化し、オーバーフローを eval エラーとして報告
- `ccc/infrastructure/src/evaluator/ast_evaluator_test/arithmetic.rs`: add/sub/mul のオーバーフローテストを 3 件追加
- `ccc/infrastructure/src/evaluator/ast_evaluator_test/power_unary.rs`: `2 ** 64` のオーバーフローテストを追加
- `docs/spec/interpreter.md`: Error Handling の「Integer negation overflow」を全整数演算のオーバーフローに更新

## 妥協と制限

- **エラーメッセージ中の演算子表記**: 累乗は `^` で入力しても `**` と表示される(AST が演算子の字面を保持しないため)。意味は同一のため受容した
- **complexity スコア**: `binary_numeric.rs` は 12.96 → 15.67 に上昇。オーバーフロー分岐 6 本の追加による本質的な増加で、ヘルパー抽出により初期実装の 16.65 から圧縮済み

## 検証方法

- 追加テスト 4 件を含む全 367 テストがパス(`cargo test --release`)
- `cargo clippy --all-targets` / `cargo fmt --check` クリーン
- 手動確認: `9223372036854775807 + 1` / `2 ** 64` / `999999999 * 999999999 * 999999999` がエラー、`2 ** 62`・通常演算は従来どおり

## 確認事項

- ⚠️ オーバーフローを「エラー」とする方針(B: float 昇格ではなく)で問題ないか
- ⚠️ duration スケーリングと `sum`/`prod` の同種オーバーフローは別 PR で対応予定

## 参考文献

- docs/spec/interpreter.md (Error Handling セクション)
- 関連 PR: #41 (同バグハントの CLI ハイフン修正)
