### PR TITLE
Correct documentation claims that diverge from implementation

### DIFF
--- a/ccc/usecase/src/format_error.rs
+++ b/ccc/usecase/src/format_error.rs
@@ -4,9 +4,9 @@ use domain::error::CccError;
 ///
 /// When the error includes position info, produces output like:
 /// ```text
-///   2 + + 3
+///   2 + * 3
 ///       ^
-///   error: expected number, function call, or '('
+///   error: expected number, function call, list, or '('
 /// ```
 pub fn format_error_with_caret(input: &str, error: &CccError) -> String {
     let position = match error {

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -51,8 +51,8 @@ cargo clippy
 
 Function names must follow the [Naming Convention](spec/naming_convention.md). In short: regular functions use **snake_case**, constructors use **PascalCase**.
 
-1. Add the function name to the match in `ccc/infrastructure/src/evaluator/builtin.rs`
-2. Add type checking rules in `ccc/infrastructure/src/type_checker/ast_type_checker.rs`
+1. Add the function name to the match in `ccc/infrastructure/src/evaluator/builtin/mod.rs`
+2. Add type checking rules in `ccc/infrastructure/src/type_checker/function_rule.rs`
 3. Add tests for both the evaluator and type checker
 4. Document the function in `docs/spec/interpreter.md` and `docs/spec/type_system.md`
 
@@ -64,7 +64,7 @@ Function names must follow the [Naming Convention](spec/naming_convention.md). I
    - Parser: `ccc/infrastructure/src/parser/pest_based_parser.rs`
    - Type checker: `ccc/infrastructure/src/type_checker/ast_type_checker.rs`
    - Evaluator: `ccc/infrastructure/src/evaluator/ast_evaluator.rs`
-4. Add the display format in `ccc/domain/src/value.rs` if a new Value variant is needed
+4. Add the display format in `ccc/domain/src/value_display.rs` if a new Value variant is needed
 5. Add tests at each layer
 
 ## Pull Requests

--- a/docs/example.md
+++ b/docs/example.md
@@ -210,17 +210,19 @@ ccc> exit
 ### Parse Error
 
 ```bash
-ccc "2 + + 3"
-#   2 + + 3
+ccc "2 + * 3"
+#   2 + * 3
 #       ^
-#   error: parse error: expected number, function call, or '('
+#   error: parse error: expected number, function call, list, or '('
 ```
+
+Note: `2 + + 3` is not a parse error — the second `+` is a unary plus, so it evaluates to `5`.
 
 ### Type Error
 
 ```bash
 ccc "1 + 1:30:00"
-#   error: type check: unsupported operation: integer + duration
+#   error: type error: unsupported operation: integer + duration
 ```
 
 ### Division by Zero

--- a/docs/spec/ast.md
+++ b/docs/spec/ast.md
@@ -118,6 +118,21 @@ Expression::List(Vec<Expression>)
 
 Example: `[1, 2, 3]` → `List([Integer(1), Integer(2), Integer(3)])`
 
+### TypeCast
+
+An explicit type conversion via the `as` operator.
+
+```rust
+Expression::TypeCast {
+    operand: Box<Expression>,
+    target_type: CastTargetType,
+}
+```
+
+`CastTargetType` is one of `Integer`, `Float`, `Timestamp`, `DateTime`.
+
+Example: `3.7 as int` → `TypeCast { operand: Float(3.7), target_type: Integer }`
+
 ### DurationTime
 
 A time duration literal in `HH:MM:SS` format.
@@ -144,11 +159,13 @@ Expression::DateTime {
     hour: u8,
     minute: u8,
     second: u8,
-    offset_seconds: i32,
+    offset: UtcOffset,
 }
 ```
 
-Example: `2025-12-25T15:30:00+09:00` → `DateTime { year: 2025, month: 12, day: 25, hour: 15, minute: 30, second: 0, offset_seconds: 32400 }`
+The offset is a `UtcOffset` value object validated at parse time (see `domain/src/time/utc_offset.rs`).
+
+Example: `2025-12-25T15:30:00+09:00` → `DateTime { year: 2025, month: 12, day: 25, hour: 15, minute: 30, second: 0, offset: UtcOffset(+09:00) }`
 
 ## Grammar
 
@@ -159,8 +176,9 @@ The parser uses PEG (Parsing Expression Grammar) via [pest](https://pest.rs/).
 1. **expression** - `term ((+ | -) term)*`
 2. **term** - `power ((* | / | %) power)*`
 3. **power** - `unary (^ unary)*` (right-associative)
-4. **unary** - `(+ | -)? atom`
-5. **atom** - function call, datetime literal, duration literal, number, list, or parenthesized expression
+4. **unary** - `(+ | -)* postfix`
+5. **postfix** - `atom (method_call | as cast_type)*` (method calls and `as` casts bind tighter than unary operators)
+6. **atom** - function call, datetime literal, duration literal, number, list, or parenthesized expression
 
 ### Literal Formats
 

--- a/docs/spec/type_checker.md
+++ b/docs/spec/type_checker.md
@@ -131,7 +131,7 @@ The `Unknown` type acts as a wildcard during type checking:
 
 - Binary operations with Unknown on either side pass through as Unknown
 - Functions that return Unknown (e.g., `head`, `tail`, `sum`, `prod`) allow any subsequent operation
-- Unknown function names pass through as Unknown (the evaluator catches them at runtime)
+- Undefined function names are rejected at type-check time with `undefined function: <name>`
 
 This allows operations like `head([1, 2, 3]) + 1` to pass type checking, deferring the actual type validation to the evaluator.
 

--- a/docs/spec/type_system.md
+++ b/docs/spec/type_system.md
@@ -126,8 +126,8 @@ Applying a unary operator to other types is a type error.
 Any combination not listed above results in a type error:
 
 ```
-  "hello" + 1
-  error: type check: unsupported operation: ...
+  1 + 1:30:00
+  error: type error: unsupported operation: integer + duration
 ```
 
 ## Function Type Rules


### PR DESCRIPTION
## 概要

ドキュメントと実装の突き合わせ監査で見つかった「事実として誤っている記述」を修正する。ソフトウェアとドキュメントの乖離をバグとして扱い、実装が正しい箇所はドキュメント側を実挙動に合わせた。

## 背景

バグハントの一環で全ドキュメント(README / docs / docs/spec)と実装の全面監査を実施した。その結果、エラーメッセージの文言・型検査の挙動・AST 構造・拡張手順のファイルパスなど、実装と食い違う記述が 7 カテゴリ見つかった。

## 課題

誤った記述はユーザーとコントリビュータの双方を惑わせる:

- `2 + + 3` は「パースエラーの例」として掲載されているが、実際は単項プラスとして `5` に評価される
- エラープレフィックスが `type check:` と記載されているが、実際の出力は `type error:`
- `"hello" + 1` という例が載っているが、この言語に文字列は存在せずパース不能
- type_checker.md は「未知の関数名は Unknown として通過し評価器が捕捉する」と主張するが、実際は型検査時に `undefined function` で拒否される
- ast.md に `TypeCast` ノードと `postfix` 優先度レベルが無く、DateTime のフィールドも実在しない `offset_seconds: i32` と記載
- contribute.md の拡張手順が存在しないファイル(`evaluator/builtin.rs` 等)を指す
- `format_error.rs` の doc コメントが古いパースエラー例を複製

## 目標

### 必須項目

- 掲載されている全コマンド例・エラー例が実際の出力と一致する
- AST 仕様が `domain/src/ast.rs` の定義と一致する
- contribute.md の拡張手順が実在のファイルを指す

### 範囲外

- 未ドキュメント機能の新規記載(`**` 演算子・メソッドチェーン・`MM:SS` duration・`show builtin`・統計関数群)— 別 PR で対応
- コードの挙動変更

## 採用手法

各乖離について「実装とドキュメントのどちらが正しいか」を判定した。今回の 7 件はすべて実装側の挙動が合理的(例: 未知関数の早期拒否はエラーを早く・確実に返す)であるため、ドキュメント側を修正した。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: ドキュメントを実挙動に合わせる(採用) | 挙動変更ゼロでリスクなし。実装側の設計はいずれも妥当 | 無し |
| B: ドキュメントに合わせて実装を変更(例: 未知関数を Unknown 通過に) | ドキュメント不変 | 型検査の早期拒否という優れた設計を後退させる。エラー文言の変更は既存テストと衝突 |

### 採用理由

監査した全項目で実装側の挙動が設計原則(早期エラー・値オブジェクトによる検証)に適っており、ドキュメントの記述が古いか誤記だったため。

## 変更箇所

- `docs/example.md`: パースエラー例を `2 + * 3` に差し替え(`2 + + 3` は 5 に評価される旨を注記)、`type check:` → `type error:`
- `docs/spec/type_system.md`: `type check:` プレフィックス修正、パース不能な `"hello" + 1` 例を実例に差し替え
- `docs/spec/type_checker.md`: 未知関数名は型検査時に拒否される旨へ修正
- `docs/spec/ast.md`: `TypeCast` ノード追加、`postfix` 優先度レベル追加、DateTime の `offset: UtcOffset` へ修正、unary の繰り返し(`*`)へ修正
- `docs/contribute.md`: 拡張手順のファイルパス 3 件を実在のパスへ修正
- `ccc/usecase/src/format_error.rs`: doc コメントの古いパースエラー例を実挙動に更新

## 妥協と制限

無し(コメント以外のコード変更を含まない)。

## 検証方法

- 修正後の全コマンド例をビルド済みバイナリで実行し、出力がドキュメントと一致することを確認
- `cargo test --release` 全テストパス(doc コメント変更が影響しないことを確認)
- ast.md の Rust スニペットを `domain/src/ast.rs` の実定義と照合

## 確認事項

- ⚠️ 「未知関数の早期拒否」を仕様として確定してよいか(ドキュメント側を直したため、この挙動が正式仕様になる)

## 参考文献

- 関連 PR: #41, #42(同バグハントの挙動修正)
- docs/spec/ast.md, docs/spec/type_checker.md, docs/spec/type_system.md
