### PR TITLE
Reject non-finite and out-of-range float-to-int casts

### DIFF
--- a/ccc/infrastructure/src/evaluator/ast_evaluator_test/type_cast.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator_test/type_cast.rs
@@ -1,4 +1,5 @@
 use domain::ast::CastTargetType;
+use domain::error::CccError;
 use domain::value::Value;
 
 use crate::test_fixture::{cast, float, int, neg};
@@ -89,4 +90,51 @@ fn cast_integer_to_int_is_identity() {
 
     // Assert
     assert_eq!(result.unwrap(), Value::Integer(3));
+}
+
+// --- Non-finite and out-of-range float to int ---
+
+#[test]
+fn cast_nan_to_int_reports_error() {
+    // Arrange
+    let expression = cast(float(f64::NAN), CastTargetType::Integer);
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("cannot cast NaN to int".to_string())
+    );
+}
+
+#[test]
+fn cast_infinity_to_int_reports_error() {
+    // Arrange
+    let expression = cast(float(f64::INFINITY), CastTargetType::Integer);
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("cannot cast inf to int".to_string())
+    );
+}
+
+#[test]
+fn cast_out_of_range_float_to_int_reports_error() {
+    // Arrange: 1e19 > i64::MAX
+    let expression = cast(float(1e19), CastTargetType::Integer);
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("float out of int range: 10000000000000000000".to_string())
+    );
 }

--- a/ccc/infrastructure/src/evaluator/value_conversion.rs
+++ b/ccc/infrastructure/src/evaluator/value_conversion.rs
@@ -15,10 +15,25 @@ pub(super) fn to_f64(value: &Value) -> Result<f64, CccError> {
 pub(super) fn to_i64(value: &Value) -> Result<i64, CccError> {
     match value {
         Value::Integer(n) => Ok(*n),
-        Value::Float(n) => Ok(*n as i64),
+        Value::Float(n) => float_to_i64(*n),
         other => Err(CccError::eval(format!(
             "expected number, got {}",
             other.type_name()
         ))),
+    }
+}
+
+// A bare `as` cast would silently turn NaN into 0 and saturate infinities and
+// out-of-range floats, so reject any float without an exact in-range truncation.
+fn float_to_i64(n: f64) -> Result<i64, CccError> {
+    if !n.is_finite() {
+        return Err(CccError::eval(format!("cannot cast {n} to int")));
+    }
+    let truncated = n.trunc();
+    // i64::MAX as f64 rounds up to 2^63 exactly, so `<` also excludes 2^63 itself.
+    if truncated >= i64::MIN as f64 && truncated < i64::MAX as f64 {
+        Ok(truncated as i64)
+    } else {
+        Err(CccError::eval(format!("float out of int range: {n}")))
     }
 }

--- a/docs/spec/type_system.md
+++ b/docs/spec/type_system.md
@@ -173,7 +173,7 @@ The `as` operator performs explicit type conversions:
 | Source | Target | Behavior |
 |--------|--------|----------|
 | Integer | Float | Widen to float |
-| Float | Integer | Truncate toward zero |
+| Float | Integer | Truncate toward zero; NaN, infinities, and values outside the i64 range are an eval error |
 | DateTime | Timestamp | Convert to epoch seconds |
 | Timestamp | DateTime | Convert to UTC datetime |
 


### PR DESCRIPTION
## 概要

`sqrt(0-4) as int` が `0` を返すバグを修正する。NaN・無限大・i64 範囲外の float から int へのキャストを eval エラーとして報告する。

## 背景

小数まわりの境界値を検査するバグハントで、非有限 float のキャストが「もっともらしい誤答」に化けることを発見した。`sqrt(0-4)` は NaN を返すが、それを `as int` すると `0` になり、エラーの痕跡が消える。

## 課題

`to_i64` が Rust の `as` 変換をそのまま使っていた。`as` は NaN を 0 に、無限大と範囲外の値を i64::MIN/MAX に飽和させる。電卓として「数でないもの」が黙って `0` になるのは、誤答をそのまま提示する故障モードである。

## 目標

### 必須項目

- NaN / ±inf の `as int` が `cannot cast <value> to int` エラーになる
- 切り捨て結果が i64 範囲外となる float の `as int` が `float out of int range: <value>` エラーになる
- 範囲内の有限 float の切り捨て(ゼロ方向)挙動は不変

### 範囲外

- `as float`・datetime/timestamp キャストの挙動変更
- 数学関数が NaN/inf を返すこと自体の扱い(`sqrt(-4)` → NaN は現状維持)

## 採用手法

`value_conversion.rs` の `to_i64` に検証付き変換 `float_to_i64` を導入する。ガード節で非有限を先に拒否し、次に切り捨て値の範囲を検査する。境界は `truncated < i64::MAX as f64` を使う: `i64::MAX as f64` は 2^63 ちょうどに丸められるため、`<` 比較で 2^63 自体も正しく排除される。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: キャスト時に検証してエラー(採用) | 誤答を返さない。既存のエラー方針(overflow / out of range)と一貫 | NaN を含む式の評価が途中で止まる |
| B: NaN → 0 / 飽和を仕様として文書化 | コード変更なし | 「sqrt(-4) as int = 0」を仕様と呼ぶのは無理がある |
| C: 数学関数が NaN/inf を返した時点でエラー | 発生源で止められる | `log(0)` → `-inf` など有用な中間値まで禁止してしまい影響範囲が大きい |

### 採用理由

非有限値は float の世界では意味を持つ(比較・表示が可能)が、int の世界には対応物がない。境界であるキャストで拒否するのが最小かつ意味的に正しい位置である。

## 変更箇所

- `ccc/infrastructure/src/evaluator/value_conversion.rs`: `float_to_i64` を導入し、非有限・範囲外 float の int キャストを eval エラー化
- `ccc/infrastructure/src/evaluator/ast_evaluator_test/type_cast.rs`: NaN / inf / 範囲外(1e19)の 3 テストを追加
- `docs/spec/type_system.md`: cast 表の Float → Integer にエラー条件を追記

## 妥協と制限

- **complexity スコア**: `value_conversion.rs` は 4.32 → 6.30。検証ロジック追加による本質的増加で、ガード節のみのフラット実装

## 検証方法

- 追加テスト 3 件を含む全 370 テストパス、clippy / fmt クリーン
- 手動確認: `sqrt(0-4) as int` と `(10.0 ** 300 * 10.0 ** 300) as int` がエラー、`3.7 as int` → `3`、`-2.9 as int` → `-2` は不変

## 確認事項

- ⚠️ 範囲外 float の扱いを「飽和」ではなく「エラー」とする方針でよいか

## 参考文献

- docs/spec/type_system.md (Type Cast セクション)
- 関連 PR: #42(同方針の整数オーバーフロー修正)
