### PR TITLE
Reject duration and aggregate overflow instead of wrapping

### DIFF
--- a/ccc/domain/src/time/duration_seconds.rs
+++ b/ccc/domain/src/time/duration_seconds.rs
@@ -1,10 +1,9 @@
-use std::ops::{Add, Div, Mul, Neg, Sub};
-
 /// Signed time span as total seconds.
 ///
 /// Distinguishes spans from epoch positions ([`super::EpochSeconds`]) at the
 /// type level, so the two kinds of "seconds" cannot be mixed up.
-/// Any i64 is a valid span; arithmetic follows plain integer semantics.
+/// Any i64 is a valid span; arithmetic that would leave the i64 range
+/// returns `None` instead of wrapping.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DurationSeconds(i64);
 
@@ -15,47 +14,51 @@ impl DurationSeconds {
 
     /// Total seconds of `HH:MM:SS` components.
     /// `minutes`/`seconds` are `u8` because literals are validated to 0-59 at parse time.
-    pub fn from_hms(hours: i64, minutes: u8, seconds: u8) -> Self {
-        Self(hours * 3600 + minutes as i64 * 60 + seconds as i64)
+    /// `None` if the total leaves the i64 range.
+    pub fn from_hms(hours: i64, minutes: u8, seconds: u8) -> Option<Self> {
+        // The minute/second contribution is < 3600, so only the hour term can overflow.
+        hours
+            .checked_mul(3600)?
+            .checked_add(minutes as i64 * 60 + seconds as i64)
+            .map(Self)
+    }
+
+    /// Total seconds of day/hour/minute/second components, each an arbitrary i64.
+    /// `None` if any intermediate term or the total leaves the i64 range.
+    pub fn from_components(days: i64, hours: i64, minutes: i64, seconds: i64) -> Option<Self> {
+        days.checked_mul(86400)?
+            .checked_add(hours.checked_mul(3600)?)?
+            .checked_add(minutes.checked_mul(60)?)?
+            .checked_add(seconds)
+            .map(Self)
     }
 
     pub fn seconds(self) -> i64 {
         self.0
     }
-}
 
-impl Add for DurationSeconds {
-    type Output = Self;
-    fn add(self, rhs: Self) -> Self {
-        Self(self.0 + rhs.0)
+    /// `None` if the combined span leaves the i64 range.
+    pub fn checked_add(self, rhs: Self) -> Option<Self> {
+        self.0.checked_add(rhs.0).map(Self)
     }
-}
 
-impl Sub for DurationSeconds {
-    type Output = Self;
-    fn sub(self, rhs: Self) -> Self {
-        Self(self.0 - rhs.0)
+    /// `None` if the combined span leaves the i64 range.
+    pub fn checked_sub(self, rhs: Self) -> Option<Self> {
+        self.0.checked_sub(rhs.0).map(Self)
     }
-}
 
-impl Neg for DurationSeconds {
-    type Output = Self;
-    fn neg(self) -> Self {
-        Self(-self.0)
+    /// `None` if the span is `i64::MIN` seconds, which has no positive counterpart.
+    pub fn checked_neg(self) -> Option<Self> {
+        self.0.checked_neg().map(Self)
     }
-}
 
-impl Mul<i64> for DurationSeconds {
-    type Output = Self;
-    fn mul(self, scalar: i64) -> Self {
-        Self(self.0 * scalar)
+    /// `None` if the scaled span leaves the i64 range.
+    pub fn checked_mul(self, scalar: i64) -> Option<Self> {
+        self.0.checked_mul(scalar).map(Self)
     }
-}
 
-/// Caller must reject a zero divisor first; division itself truncates.
-impl Div<i64> for DurationSeconds {
-    type Output = Self;
-    fn div(self, divisor: i64) -> Self {
-        Self(self.0 / divisor)
+    /// Truncating division. `None` for a zero divisor or `i64::MIN / -1`.
+    pub fn checked_div(self, divisor: i64) -> Option<Self> {
+        self.0.checked_div(divisor).map(Self)
     }
 }

--- a/ccc/infrastructure/src/evaluator/ast_evaluator.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator.rs
@@ -55,9 +55,9 @@ pub(super) fn evaluate_expression(expression: &Expression) -> Result<Value, CccE
             hours,
             minutes,
             seconds,
-        } => Ok(Value::DurationTime(DurationSeconds::from_hms(
-            *hours, *minutes, *seconds,
-        ))),
+        } => DurationSeconds::from_hms(*hours, *minutes, *seconds)
+            .map(Value::DurationTime)
+            .ok_or_else(|| CccError::eval("duration out of range")),
         Expression::DateTime {
             year,
             month,

--- a/ccc/infrastructure/src/evaluator/ast_evaluator_test/duration.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator_test/duration.rs
@@ -1,3 +1,5 @@
+use domain::error::CccError;
+
 use crate::test_fixture::{add, call, div, duration_literal, duration_value, int, mul, neg, sub};
 
 use super::eval;
@@ -169,4 +171,72 @@ fn eval_duration_divide_zero_is_error() {
 
     // Assert
     assert!(result.is_err());
+}
+
+// --- Overflow ---
+
+#[test]
+fn eval_duration_literal_overflow_is_error() {
+    // Arrange: 9999999999999999 hours exceed the i64 seconds range
+    let expression = duration_literal(9_999_999_999_999_999, 0, 0);
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("duration out of range".to_string())
+    );
+}
+
+#[test]
+fn eval_duration_constructor_overflow_is_error() {
+    // Arrange: DurationTime(99999999999999999 days, 0, 0, 0)
+    let expression = call(
+        "DurationTime",
+        vec![int(99_999_999_999_999_999), int(0), int(0), int(0)],
+    );
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("DurationTime: duration out of range".to_string())
+    );
+}
+
+#[test]
+fn eval_duration_add_overflow_is_error() {
+    // Arrange: i64::MAX seconds is 2562047788015215:30:07; adding one second overflows
+    let expression = add(
+        duration_literal(2_562_047_788_015_215, 30, 7),
+        duration_literal(0, 0, 1),
+    );
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("duration out of range".to_string())
+    );
+}
+
+#[test]
+fn eval_duration_multiply_overflow_is_error() {
+    // Arrange
+    let expression = mul(duration_literal(2_562_047_788_015_215, 0, 0), int(2));
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("duration out of range".to_string())
+    );
 }

--- a/ccc/infrastructure/src/evaluator/ast_evaluator_test/list.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator_test/list.rs
@@ -1,6 +1,7 @@
+use domain::error::CccError;
 use domain::value::Value;
 
-use crate::test_fixture::{add, int, list, mul};
+use crate::test_fixture::{add, call, int, list, mul};
 
 use super::eval;
 
@@ -67,5 +68,37 @@ fn eval_nested_list() {
             Value::List(vec![Value::Integer(1)]),
             Value::List(vec![Value::Integer(2)]),
         ])
+    );
+}
+
+// --- Aggregate overflow ---
+
+#[test]
+fn eval_sum_overflow_is_error() {
+    // Arrange: sum([i64::MAX, 1])
+    let expression = call("sum", vec![list(vec![int(i64::MAX), int(1)])]);
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("sum: integer overflow".to_string())
+    );
+}
+
+#[test]
+fn eval_prod_overflow_is_error() {
+    // Arrange: prod([i64::MAX, 2])
+    let expression = call("prod", vec![list(vec![int(i64::MAX), int(2)])]);
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("prod: integer overflow".to_string())
     );
 }

--- a/ccc/infrastructure/src/evaluator/binary_duration.rs
+++ b/ccc/infrastructure/src/evaluator/binary_duration.rs
@@ -5,17 +5,24 @@ use domain::value::Value;
 
 use super::binary_operation::unsupported_binary_op;
 
+fn duration_out_of_range() -> CccError {
+    CccError::eval("duration out of range")
+}
+
 /// DurationTime ± DurationTime → DurationTime
 pub(super) fn combine_durations(
     operator: &BinaryOperation,
     left: DurationSeconds,
     right: DurationSeconds,
 ) -> Result<Value, CccError> {
-    match operator {
-        BinaryOperation::Add => Ok(Value::DurationTime(left + right)),
-        BinaryOperation::Subtract => Ok(Value::DurationTime(left - right)),
-        _ => Err(unsupported_binary_op(operator, "duration", "duration")),
-    }
+    let combined = match operator {
+        BinaryOperation::Add => left.checked_add(right),
+        BinaryOperation::Subtract => left.checked_sub(right),
+        _ => return Err(unsupported_binary_op(operator, "duration", "duration")),
+    };
+    combined
+        .map(Value::DurationTime)
+        .ok_or_else(duration_out_of_range)
 }
 
 /// DurationTime */÷ Integer → DurationTime
@@ -25,12 +32,18 @@ pub(super) fn scale_duration_by_integer(
     scalar: i64,
 ) -> Result<Value, CccError> {
     match operator {
-        BinaryOperation::Multiply => Ok(Value::DurationTime(duration * scalar)),
+        BinaryOperation::Multiply => duration
+            .checked_mul(scalar)
+            .map(Value::DurationTime)
+            .ok_or_else(duration_out_of_range),
         BinaryOperation::Divide => {
             if scalar == 0 {
                 return Err(CccError::eval("division by zero"));
             }
-            Ok(Value::DurationTime(duration / scalar))
+            duration
+                .checked_div(scalar)
+                .map(Value::DurationTime)
+                .ok_or_else(duration_out_of_range)
         }
         _ => Err(unsupported_binary_op(operator, "duration", "integer")),
     }
@@ -43,7 +56,10 @@ pub(super) fn multiply_integer_by_duration(
     duration: DurationSeconds,
 ) -> Result<Value, CccError> {
     match operator {
-        BinaryOperation::Multiply => Ok(Value::DurationTime(duration * scalar)),
+        BinaryOperation::Multiply => duration
+            .checked_mul(scalar)
+            .map(Value::DurationTime)
+            .ok_or_else(duration_out_of_range),
         _ => Err(unsupported_binary_op(operator, "integer", "duration")),
     }
 }

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_constructor.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_constructor.rs
@@ -28,10 +28,9 @@ pub fn duration_time_constructor(arguments: &[Value]) -> Result<Value, CccError>
         )
     };
 
-    let total_seconds = days * 86400 + hours * 3600 + minutes * 60 + seconds;
-    Ok(Value::DurationTime(DurationSeconds::from_seconds(
-        total_seconds,
-    )))
+    DurationSeconds::from_components(days, hours, minutes, seconds)
+        .map(Value::DurationTime)
+        .ok_or_else(|| CccError::eval("DurationTime: duration out of range"))
 }
 
 pub fn datetime_constructor(arguments: &[Value]) -> Result<Value, CccError> {

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_helpers/collection.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_helpers/collection.rs
@@ -39,12 +39,13 @@ pub fn collect_integers(name: &str, elements: &[Value]) -> Result<Vec<i64>, CccE
 }
 
 /// Fold numeric list elements with an accumulator, preserving int/float distinction.
+/// The integer op is checked: overflow reports an eval error instead of wrapping.
 pub fn fold_numbers(
     name: &str,
     elements: &[Value],
     int_identity: i64,
     float_identity: f64,
-    int_op: fn(i64, i64) -> i64,
+    int_op: fn(i64, i64) -> Option<i64>,
     float_op: fn(f64, f64) -> f64,
 ) -> Result<Value, CccError> {
     let mut has_float = false;
@@ -54,7 +55,8 @@ pub fn fold_numbers(
     for elem in elements {
         match elem {
             Value::Integer(n) => {
-                int_acc = int_op(int_acc, *n);
+                int_acc = int_op(int_acc, *n)
+                    .ok_or_else(|| CccError::eval(format!("{name}: integer overflow")))?;
                 float_acc = float_op(float_acc, *n as f64);
             }
             Value::Float(n) => {

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_list.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_list.rs
@@ -6,6 +6,12 @@ use domain::value::Value;
 
 use super::builtin_helpers::{collect_seconds, expect_single_list, fold_numbers};
 
+fn sum_seconds_checked(name: &str, secs: &[i64]) -> Result<i64, CccError> {
+    secs.iter()
+        .try_fold(0i64, |acc, s| acc.checked_add(*s))
+        .ok_or_else(|| CccError::eval(format!("{name}: duration overflow")))
+}
+
 pub fn list_len(arguments: &[Value]) -> Result<Value, CccError> {
     let elements = expect_single_list("len", arguments)?;
     Ok(Value::Integer(elements.len() as i64))
@@ -19,16 +25,16 @@ pub fn list_sum(arguments: &[Value]) -> Result<Value, CccError> {
         Some(Value::DurationTime(_)) => {
             let secs = collect_seconds("sum", elements)?;
             Ok(Value::DurationTime(DurationSeconds::from_seconds(
-                secs.iter().sum(),
+                sum_seconds_checked("sum", &secs)?,
             )))
         }
-        _ => fold_numbers("sum", elements, 0, 0.0, i64::wrapping_add, f64::add),
+        _ => fold_numbers("sum", elements, 0, 0.0, i64::checked_add, f64::add),
     }
 }
 
 pub fn list_prod(arguments: &[Value]) -> Result<Value, CccError> {
     let elements = expect_single_list("prod", arguments)?;
-    fold_numbers("prod", elements, 1, 1.0, i64::wrapping_mul, f64::mul)
+    fold_numbers("prod", elements, 1, 1.0, i64::checked_mul, f64::mul)
 }
 
 pub fn list_head(arguments: &[Value]) -> Result<Value, CccError> {

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_statistics.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_statistics.rs
@@ -10,7 +10,10 @@ pub fn list_mean(arguments: &[Value]) -> Result<Value, CccError> {
     match elements.first() {
         Some(Value::DurationTime(_)) => {
             let secs = collect_seconds("mean", elements)?;
-            let total: i64 = secs.iter().sum();
+            let total = secs
+                .iter()
+                .try_fold(0i64, |acc, s| acc.checked_add(*s))
+                .ok_or_else(|| CccError::eval("mean: duration overflow"))?;
             Ok(Value::DurationTime(DurationSeconds::from_seconds(
                 total / secs.len() as i64,
             )))
@@ -65,6 +68,10 @@ fn median_sorted_i64(secs: &[i64]) -> i64 {
     if n % 2 == 1 {
         secs[n / 2]
     } else {
-        (secs[n / 2 - 1] + secs[n / 2]) / 2
+        let low = secs[n / 2 - 1];
+        let high = secs[n / 2];
+        // low + (high - low) / 2 cannot overflow because low <= high after sorting,
+        // unlike (low + high) / 2 whose intermediate sum can leave the i64 range.
+        low + (high - low) / 2
     }
 }

--- a/ccc/infrastructure/src/evaluator/unary_operation.rs
+++ b/ccc/infrastructure/src/evaluator/unary_operation.rs
@@ -9,7 +9,10 @@ pub(super) fn evaluate_unary(operator: &UnaryOperation, value: &Value) -> Result
             .map(Value::Integer)
             .ok_or_else(|| CccError::eval("integer negation overflow".to_string())),
         (UnaryOperation::Negate, Value::Float(n)) => Ok(Value::Float(-n)),
-        (UnaryOperation::Negate, Value::DurationTime(s)) => Ok(Value::DurationTime(-*s)),
+        (UnaryOperation::Negate, Value::DurationTime(s)) => s
+            .checked_neg()
+            .map(Value::DurationTime)
+            .ok_or_else(|| CccError::eval("duration negation overflow".to_string())),
         (UnaryOperation::Negate, v) => {
             Err(CccError::eval(format!("cannot negate a {}", v.type_name())))
         }

--- a/docs/spec/interpreter.md
+++ b/docs/spec/interpreter.md
@@ -145,6 +145,7 @@ The evaluator produces `CccError::Eval` for runtime errors:
 
 - Division/modulo by zero
 - Integer overflow (addition, subtraction, multiplication, power, negation)
+- Duration out of range (literals, constructors, arithmetic, and aggregation whose total seconds leave the i64 range)
 - Invalid datetime components
 - Unknown function names
 - Argument count mismatches


### PR DESCRIPTION
## 概要

duration 演算・リスト集約に残っていたサイレントな整数オーバーフローを修正する。#42(スカラー整数演算の checked 化)のフォローアップとして予告していた同クラスのバグをすべて潰す。

## 背景

#42 のレビューで「duration スケーリングと `sum`/`prod` の同種オーバーフローは別 PR で対応予定」と宣言していた。追加調査で literal・コンストラクタにも同じ穴があることが判明した。

## 課題

以下がすべて黙って wrap し、誤った値を返していた:

- `9999999999999999:00:00` → `-248191152060863:00:32`(`from_hms` の時間乗算が未チェック)
- `DurationTime(99999999999999999, 0, 0, 0)` → 同様に wrap
- duration の `+` `-` `*` `/` と単項 `-`(`i64::MIN / -1`、`-i64::MIN` のエッジ含む)
- `sum`/`prod` は **明示的に** `i64::wrapping_add` / `wrapping_mul` を使用
- duration の `sum`/`mean` は未チェックのイテレータ和、`median` の偶数要素中点 `(a+b)/2` は中間和が溢れ得る

datetime 演算(`EpochSeconds::checked_add`)だけが正しく、duration 側が全面的に検査漏れという非一貫な状態だった。

## 目標

### 必須項目

- duration の literal・コンストラクタ・二項演算・単項否定・集約が、i64 範囲を超える場合に eval エラーを返す
- `sum`/`prod` の整数オーバーフローが `<fn>: integer overflow` エラーになる
- 通常範囲の全挙動(切り捨て除算・型昇格)は不変

### 範囲外

- Timestamp(f64)演算の精度・飽和の扱い
- 集約関数の float 精度

## 採用手法

`DurationSeconds` の演算子オーバーロード(`Add`/`Sub`/`Neg`/`Mul`/`Div`)を廃止し、`EpochSeconds` と同型の checked メソッド群(`checked_add/sub/neg/mul/div`, `from_hms`/`from_components` は `Option<Self>` を返す)へ置き換えた。「オーバーフローし得る演算を演算子として書けない」ことを型で強制する(Make Illegal States Unrepresentable)。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: 演算子を削除し checked メソッドのみ(採用) | 未チェック演算の再発を型レベルで防止。EpochSeconds と対称 | 呼び出し側がやや冗長 |
| B: 演算子内部で saturate | 呼び出し側は不変 | 飽和も「黙って違う値」であり問題が残る。Add trait は Result を返せない |
| C: 演算子と checked メソッドを併存 | 移行が容易 | wrap する演算子が残り、将来の呼び出しが再びバグる |

### 採用理由

演算子が存在する限り「うっかり `+` を書く」経路が残る。ドメイン層の値オブジェクトから危険な操作自体を消すのが本質的な再発防止であり、既存の `EpochSeconds` と設計が揃う。

```mermaid
flowchart LR
  subgraph domain
    DS[DurationSeconds<br>checked_add/sub/neg/mul/div<br>from_hms/from_components → Option]
  end
  subgraph infrastructure
    BD[binary_duration] --> DS
    UO[unary_operation] --> DS
    AE[ast_evaluator literal] --> DS
    BC[builtin_constructor] --> DS
    BL[builtin_list sum/prod] -->|checked fold| ERR[eval error]
    BS[builtin_statistics mean/median] --> ERR
  end
```

## 変更箇所

- `ccc/domain/src/time/duration_seconds.rs`: 演算子 impl を checked メソッド群に置換、`from_hms`/`from_components` を `Option` 返却に
- `ccc/infrastructure/src/evaluator/binary_duration.rs`: 全演算を checked 化し `duration out of range` を報告
- `ccc/infrastructure/src/evaluator/unary_operation.rs`: duration 否定を `checked_neg` 化
- `ccc/infrastructure/src/evaluator/ast_evaluator.rs`: literal 評価で範囲エラーを報告
- `ccc/infrastructure/src/evaluator/builtin/builtin_constructor.rs`: `DurationTime()` を `from_components` 経由に
- `ccc/infrastructure/src/evaluator/builtin/builtin_helpers/collection.rs`: `fold_numbers` の整数 op を `Option` 返却の checked 契約に変更
- `ccc/infrastructure/src/evaluator/builtin/builtin_list.rs`: `sum`/`prod` を checked 化(duration 和も checked fold)
- `ccc/infrastructure/src/evaluator/builtin/builtin_statistics.rs`: duration の `mean` を checked 和に、`median` 中点をオーバーフローしない形 `low + (high - low) / 2` に
- `ccc/infrastructure/src/evaluator/ast_evaluator_test/{duration,list}.rs`: オーバーフロー回帰テスト 6 件を追加
- `docs/spec/interpreter.md`: Error Handling に duration out of range を追記

## 妥協と制限

- **エラーメッセージの粒度**: duration 系は一律 `duration out of range` とし、どの演算で溢れたかは含めない(整数系の `integer overflow: <left> <op> <right>` より粗い)。duration 値の表示が長く、メッセージが読みにくくなるため

## 検証方法

- 追加テスト 6 件を含む全 376 テストパス、clippy / fmt クリーン
- 手動確認: 上記の全 wrap ケースがエラーになり、`1:30:00`、`DurationTime(1,30,0)`、`3:00:00 / 2`、`sum([1,2,3])`、`mean([1:30, 0:30])` は従来どおり

## 確認事項

- ⚠️ `DurationSeconds` の演算子オーバーロード削除(domain 層の公開 API 変更)を許容できるか

## 参考文献

- 関連 PR: #42(スカラー整数演算の checked 化)
- docs/spec/interpreter.md (Error Handling セクション)
