### PR TITLE
Document implemented-but-undocumented features

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -20,7 +20,12 @@ ccc "10 % 3"
 
 ccc "2 ^ 10"
 # 1024
+
+ccc "2 ** 10"
+# 1024
 ```
+
+`**` is a synonym for `^`; both mean power.
 
 ## Operator Precedence
 
@@ -100,7 +105,55 @@ ccc "tail([10, 20, 30])"
 # [20, 30]
 ```
 
+## Statistics Functions
+
+```bash
+ccc "mean([1, 2, 3])"
+# 2
+
+ccc "median([1, 2, 3, 4])"
+# 2.5
+
+ccc "variance([1, 2, 3])"
+# 0.6666666666666666
+
+ccc "min([3, 1, 2])"
+# 1
+
+ccc "max([3, 1, 2])"
+# 3
+```
+
+`mean`, `median`, `min`, and `max` also work on duration lists:
+
+```bash
+ccc "mean([1:30:00, 0:30:00])"
+# 1:00:00
+```
+
+## Method Chains
+
+Any function can be called postfix: `x.f(a)` desugars to `f(x, a)`.
+
+```bash
+ccc "[1, 2, 3].sum()"
+# 6
+
+ccc "[1, 2, 3].tail().sum()"
+# 5
+
+ccc "2.5.floor()"
+# 2
+```
+
 ## Duration Arithmetic
+
+Durations are written as `H:MM:SS`. A two-part literal is `MM:SS` (minutes and seconds):
+
+```bash
+ccc "5:30"
+# 0:05:30
+```
 
 ```bash
 ccc "1:30:00 + 0:45:00"
@@ -188,6 +241,14 @@ printf "1 + 1\n2 + 2\n3 + 3" | ccc
 # 2
 # 4
 # 6
+```
+
+## Show Built-in Functions
+
+List every built-in function with its signature:
+
+```bash
+ccc show builtin
 ```
 
 ## REPL

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -83,6 +83,12 @@ echo "10" | ccc "+ 5"
 # 15
 ```
 
+### List built-in functions
+
+```bash
+ccc show builtin
+```
+
 ## What's Next
 
 - [Examples](example.md) - More usage examples

--- a/docs/spec/ast.md
+++ b/docs/spec/ast.md
@@ -53,7 +53,7 @@ Operators:
 | Multiply | `*` | Medium | Left |
 | Divide | `/` | Medium | Left |
 | Modulo | `%` | Medium | Left |
-| Power | `^` | High | Right |
+| Power | `^` or `**` | High | Right |
 
 Example: `2 + 3 * 4` →
 
@@ -135,7 +135,7 @@ Example: `3.7 as int` → `TypeCast { operand: Float(3.7), target_type: Integer 
 
 ### DurationTime
 
-A time duration literal in `HH:MM:SS` format.
+A time duration literal in `HH:MM:SS` format, or `MM:SS` with hours = 0.
 
 ```rust
 Expression::DurationTime {
@@ -175,7 +175,7 @@ The parser uses PEG (Parsing Expression Grammar) via [pest](https://pest.rs/).
 
 1. **expression** - `term ((+ | -) term)*`
 2. **term** - `power ((* | / | %) power)*`
-3. **power** - `unary (^ unary)*` (right-associative)
+3. **power** - `unary ((^ | **) unary)*` (right-associative)
 4. **unary** - `(+ | -)* postfix`
 5. **postfix** - `atom (method_call | as cast_type)*` (method calls and `as` casts bind tighter than unary operators)
 6. **atom** - function call, datetime literal, duration literal, number, list, or parenthesized expression
@@ -186,10 +186,15 @@ The parser uses PEG (Parsing Expression Grammar) via [pest](https://pest.rs/).
 |------|--------|---------|
 | Integer | `[0-9]+` | `42` |
 | Float | `[0-9]+.[0-9]+` | `3.14` |
-| Duration | `[0-9]+:[0-9]{2}:[0-9]{2}` | `1:30:00` |
+| Duration | `[0-9]+:[0-9]{2}:[0-9]{2}` (H:MM:SS) | `1:30:00` |
+| Duration | `[0-9]+:[0-9]{2}` (MM:SS, hours = 0) | `5:30` |
 | DateTime | `YYYY-MM-DDTHH:MM:SS[tz]` | `2025-12-25T15:30:00Z` |
 
 DateTime timezone formats: `Z`, `+09:00`, `-05`, `+09`
+
+### Method Calls
+
+A postfix method call `x.f(a, b)` desugars to the function call `f(x, a, b)` at parse time; the AST contains only `FunctionCall` nodes. Calls chain left to right: `[1, 2, 3].tail().sum()` is `sum(tail([1, 2, 3]))`.
 
 ### Whitespace
 

--- a/docs/spec/interpreter.md
+++ b/docs/spec/interpreter.md
@@ -93,12 +93,17 @@ All accept a numeric argument (Integer or Float) and return Float.
 | Function | Description | Error Condition |
 |----------|-------------|-----------------|
 | `len(list)` | Number of elements | |
-| `sum(list)` | Sum of numeric elements | Non-numeric elements |
+| `sum(list)` | Sum of numeric or duration elements | Mixed element types |
 | `prod(list)` | Product of numeric elements | Non-numeric elements |
 | `head(list)` | First element | Empty list |
 | `tail(list)` | All elements except the first | Empty list |
+| `mean(list)` | Arithmetic mean of numeric or duration elements | Empty list, mixed element types |
+| `median(list)` | Median of numeric or duration elements | Empty list, mixed element types |
+| `variance(list)` | Population variance of numeric elements | Empty list, non-numeric elements |
+| `max(list)` | Largest element (numeric or duration) | Empty list, mixed element types |
+| `min(list)` | Smallest element (numeric or duration) | Empty list, mixed element types |
 
-`sum` and `prod` return Integer if all elements are Integer, otherwise Float.
+`sum` and `prod` return Integer if all elements are Integer, otherwise Float. `mean`, `median`, and `variance` return Float for numeric lists; `max` and `min` preserve the element type. `sum`, `mean`, `median`, `max`, and `min` return DurationTime for duration lists.
 
 ### Time Constructors
 

--- a/docs/spec/type_checker.md
+++ b/docs/spec/type_checker.md
@@ -77,7 +77,7 @@ Nested expressions in arguments are also type-checked.
 
 ### List Functions
 
-`len`, `sum`, `prod`, `head`, `tail`:
+`len`, `sum`, `prod`, `head`, `tail`, `mean`, `variance`, `median`, `max`, `min`:
 
 - Exactly 1 argument
 - Argument must be List

--- a/docs/spec/type_system.md
+++ b/docs/spec/type_system.md
@@ -42,11 +42,12 @@ A sequence of values. Elements can be of any type.
 
 ### DurationTime
 
-A time duration stored as total seconds (signed `i64`). Represented in `HH:MM:SS` format.
+A time duration stored as total seconds (signed `i64`). Displayed in `H:MM:SS` format. Literals accept `H:MM:SS` or the two-part `MM:SS` form (minutes and seconds).
 
 ```
 1:30:00
 0:05:30
+5:30
 ```
 
 Negative durations are displayed with a leading `-`:
@@ -155,8 +156,13 @@ All require a numeric argument (Integer or Float) and return Float.
 | `prod` | List | Unknown |
 | `head` | List | Unknown |
 | `tail` | List | Unknown |
+| `mean` | List | Unknown |
+| `variance` | List | Unknown |
+| `median` | List | Unknown |
+| `max` | List | Unknown |
+| `min` | List | Unknown |
 
-`sum`, `prod`, `head`, `tail` return Unknown because element types are not tracked statically.
+All list functions except `len` return Unknown because element types are not tracked statically. At runtime, `mean`/`median`/`variance` return Float for numeric lists, `max`/`min` preserve the element type, and `mean`/`median`/`max`/`min` also accept duration lists (returning DurationTime).
 
 ### Time Constructors
 


### PR DESCRIPTION
## 概要

実装済みなのにドキュメントに存在しない 5 機能を記載する。#43(誤記述の修正)と対になる「記載漏れ」側の解消であり、ソフトウェアとドキュメントの乖離をバグとして扱う。

## 背景

全ドキュメントと実装の突き合わせ監査で、乖離は「ドキュメントが間違っている」(#43 で修正済)と「機能が書かれていない」の 2 種に分類された。本 PR は後者を扱う。

## 課題

以下がすべて動作するのに、どのドキュメントからも発見できなかった:

- `**` 累乗演算子(`^` の同義語。grammar.pest で定義済み)
- メソッドチェーン構文 `x.f(a)` → `f(x, a)`(パーサで desugar、テストも存在)
- 2 要素 duration リテラル `MM:SS`(`5:30` = 5 分 30 秒。時分と誤解しやすく、記載がないと危険)
- `ccc show builtin` サブコマンド
- 統計組み込み関数 `mean` / `variance` / `median` / `max` / `min`(登録・型検査済みだが spec の全テーブルから欠落)

## 目標

### 必須項目

- 5 機能すべてがユーザー向け(example.md / getting_started.md)と仕様(spec/*)の両方から到達可能
- 掲載する例の出力が実バイナリの出力と一致する

### 範囲外

- コードの挙動変更(本 PR はドキュメントのみ)
- 統計関数の静的型を Unknown より精密にする改善

## 採用手法

各機能を「ユーザーが探す場所」(example.md, getting_started.md)と「仕様として正である場所」(spec/ast.md, type_system.md, interpreter.md, type_checker.md)の両方に、既存セクションの構成・文体に合わせて追記した。掲載例は全件ビルド済みバイナリで実行し出力を転記した。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: 既存ドキュメント構成に追記(採用) | 読者の導線が変わらず、差分が最小 | 無し |
| B: 機能一覧ページを新設 | 網羅性の一元管理 | 既存の example / spec 分担と重複し、二重管理になる |

### 採用理由

既存ドキュメントは「example = 使い方」「spec = 仕様」の分担が確立しており、そこに欠けを埋めるのが最も保守しやすい。

## 変更箇所

- `docs/example.md`: `**`、Statistics Functions、Method Chains、`MM:SS` duration、`show builtin` の各セクション/例を追加
- `docs/getting_started.md`: Basic Usage に `ccc show builtin` を追加
- `docs/spec/ast.md`: Power 演算子表と precedence に `**`、literal 表に `MM:SS`、Method Calls の desugar 仕様を追加
- `docs/spec/type_system.md`: List Functions 表に統計 5 関数を追加、duration リテラルの 2 形式を明記
- `docs/spec/interpreter.md`: 組み込み関数表に統計 5 関数(挙動・エラー条件・戻り型)を追加
- `docs/spec/type_checker.md`: List Functions の検証規則に統計 5 関数を追加

## 妥協と制限

- **統計関数の静的型**: 実装どおり Unknown と記載した。ランタイムの実際の戻り型は表外の注記で補った

## 検証方法

- 追加した全コマンド例をビルド済みバイナリで実行し、出力一致を確認(`2 ** 10` → 1024、`5:30` → 0:05:30、`mean([1:30:00, 0:30:00])` → 1:00:00 等)
- `cargo test --release` 全 8 スイートパス(ドキュメントのみの変更であることの確認)

## 確認事項

- ⚠️ `MM:SS` の「分:秒」解釈を仕様として明文化してよいか(「時:分」と期待するユーザーもいる可能性がある)

## 参考文献

- 関連 PR: #43(乖離のうち「誤記述」側の修正)
- ccc/infrastructure/src/parser/grammar.pest(`**`・`MM:SS`・method_call の定義)
