### PR TITLE
Reject NaN timestamp to datetime cast

### DIFF
--- a/ccc/infrastructure/src/evaluator/ast_evaluator_test/timestamp.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator_test/timestamp.rs
@@ -141,3 +141,45 @@ fn eval_round_trip_datetime_timestamp() {
         panic!("expected DateTime");
     }
 }
+
+#[test]
+fn cast_nan_timestamp_to_datetime_is_error() {
+    // Arrange: Timestamp(NaN) as datetime — NaN must not become epoch 0
+    use crate::test_fixture::{cast, float};
+    use domain::ast::CastTargetType;
+    use domain::error::CccError;
+    let expression = cast(
+        call("Timestamp", vec![float(f64::NAN)]),
+        CastTargetType::DateTime,
+    );
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("cannot cast NaN timestamp to datetime".to_string())
+    );
+}
+
+#[test]
+fn cast_infinite_timestamp_to_datetime_is_error() {
+    // Arrange
+    use crate::test_fixture::{cast, float};
+    use domain::ast::CastTargetType;
+    use domain::error::CccError;
+    let expression = cast(
+        call("Timestamp", vec![float(f64::INFINITY)]),
+        CastTargetType::DateTime,
+    );
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("timestamp out of datetime range".to_string())
+    );
+}

--- a/ccc/infrastructure/src/evaluator/type_cast.rs
+++ b/ccc/infrastructure/src/evaluator/type_cast.rs
@@ -26,6 +26,11 @@ pub(super) fn evaluate_type_cast(
             ))),
         },
         CastTargetType::DateTime => match value {
+            // NaN would silently become epoch 0 through `as i64`; reject it upfront.
+            // Infinities saturate and then fail the EpochSeconds range check below.
+            Value::Timestamp(ts) if ts.is_nan() => {
+                Err(CccError::eval("cannot cast NaN timestamp to datetime"))
+            }
             Value::Timestamp(ts) => EpochSeconds::from_seconds(*ts as i64)
                 .map(|epoch| Value::DateTime {
                     epoch,


### PR DESCRIPTION
## 概要

`Timestamp(sqrt(0-4)) as datetime` が `1970-01-01T00:00:00Z` を返すバグを修正する。NaN の timestamp から datetime へのキャストを eval エラーとして報告する。

## 背景

#44(float → int キャストの NaN 拒否)のマージ後、同じ「NaN が `as i64` で 0 に化ける」経路が timestamp → datetime キャストにも残っていないかを追加検査し、再現を確認した。

## 課題

`type_cast.rs` の DateTime アームは `*ts as i64` で epoch 秒へ変換していた。`NaN as i64` は 0 になり、epoch 0 は有効な日時(Unix epoch)であるため `EpochSeconds` の範囲検査をすり抜け、「数でないもの」が 1970-01-01 という もっともらしい日時に化けていた。無限大は i64::MIN/MAX に飽和して範囲検査で落ちるため、サイレントに通るのは NaN のみ。

## 目標

### 必須項目

- `Timestamp(NaN) as datetime` が `cannot cast NaN timestamp to datetime` エラーになる
- 有限 timestamp のキャスト・無限大の既存エラー(`timestamp out of datetime range`)は不変

### 範囲外

- `Timestamp - Timestamp` の小数秒切り捨て(整数秒 duration への変換に内在)
- Timestamp コンストラクタが NaN を受理すること自体の可否

## 採用手法

DateTime アームに NaN ガードを追加する。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: キャスト時に NaN をガード(採用) | 最小差分。#44 と同じ「境界で拒否」方針 | Timestamp 値として NaN は存在し続ける |
| B: `Timestamp()` コンストラクタで NaN を拒否 | 発生源で遮断 | `current_timestamp()` 等の他経路との整合検討が必要で、影響範囲が広い。別議論とすべき |

### 採用理由

int の世界に対応物がない値を境界(キャスト)で拒否するのは #44 で確立した方針であり、その対称形として最小のリスクで穴を塞げる。

## 変更箇所

- `ccc/infrastructure/src/evaluator/type_cast.rs`: DateTime キャストに NaN ガードを追加
- `ccc/infrastructure/src/evaluator/ast_evaluator_test/timestamp.rs`: NaN(新エラー)と無限大(既存エラーの pin)のテスト 2 件を追加

## 妥協と制限

- **NaN Timestamp の存続**: `Timestamp(sqrt(0-4))` 自体は引き続き `NaN` を生成・表示できる。キャスト境界のみで拒否する

## 検証方法

- 追加テスト 2 件を含む全 378 テストパス、clippy / fmt クリーン
- 手動確認: `Timestamp(sqrt(0-4)) as datetime` がエラー、`Timestamp(0) as datetime` → `1970-01-01T00:00:00Z` は不変

## 確認事項

- ⚠️ 将来的に `Timestamp()` コンストラクタ側で非有限値を拒否するか(選択肢 B)は別 Issue として検討したい

## 参考文献

- 関連 PR: #44(float → int キャストの NaN / 範囲外拒否)
