### PR TITLE
Use the canonical operator symbol in overflow messages

### DIFF
--- a/ccc/infrastructure/src/evaluator/ast_evaluator_test/power_unary.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator_test/power_unary.rs
@@ -45,7 +45,7 @@ fn power_float_base() {
 
 #[test]
 fn power_overflow_reports_error() {
-    // Arrange: 2 ** 64 exceeds i64::MAX
+    // Arrange: 2 ^ 64 exceeds i64::MAX; the message uses the canonical `^` symbol
     let expression = pow(int(2), int(64));
 
     // Act
@@ -54,7 +54,7 @@ fn power_overflow_reports_error() {
     // Assert
     assert_eq!(
         result.unwrap_err(),
-        CccError::eval("integer overflow: 2 ** 64".to_string())
+        CccError::eval("integer overflow: 2 ^ 64".to_string())
     );
 }
 

--- a/ccc/infrastructure/src/evaluator/binary_numeric.rs
+++ b/ccc/infrastructure/src/evaluator/binary_numeric.rs
@@ -22,9 +22,9 @@ fn checked_integer(
         .ok_or_else(|| integer_overflow_error(left, operator_symbol, right))
 }
 
-fn evaluate_integer_power(left: i64, right: i64) -> Result<Value, CccError> {
+fn evaluate_integer_power(left: i64, right: i64, symbol: &str) -> Result<Value, CccError> {
     if right >= 0 && right <= u32::MAX as i64 {
-        checked_integer(left.checked_pow(right as u32), left, "**", right)
+        checked_integer(left.checked_pow(right as u32), left, symbol, right)
     } else {
         Ok(Value::Float((left as f64).powf(right as f64)))
     }
@@ -35,10 +35,12 @@ pub(super) fn evaluate_binary_integer(
     left: i64,
     right: i64,
 ) -> Result<Value, CccError> {
+    // operator.symbol() keeps overflow messages consistent with type-check errors.
+    let symbol = operator.symbol();
     match operator {
-        BinaryOperation::Add => checked_integer(left.checked_add(right), left, "+", right),
-        BinaryOperation::Subtract => checked_integer(left.checked_sub(right), left, "-", right),
-        BinaryOperation::Multiply => checked_integer(left.checked_mul(right), left, "*", right),
+        BinaryOperation::Add => checked_integer(left.checked_add(right), left, symbol, right),
+        BinaryOperation::Subtract => checked_integer(left.checked_sub(right), left, symbol, right),
+        BinaryOperation::Multiply => checked_integer(left.checked_mul(right), left, symbol, right),
         BinaryOperation::Divide => {
             if right == 0 {
                 return Err(CccError::eval(format!(
@@ -58,7 +60,7 @@ pub(super) fn evaluate_binary_integer(
             }
             Ok(Value::Integer(left % right))
         }
-        BinaryOperation::Power => evaluate_integer_power(left, right),
+        BinaryOperation::Power => evaluate_integer_power(left, right, symbol),
     }
 }
 


### PR DESCRIPTION
## 概要

累乗のオーバーフローエラーが `integer overflow: 2 ** 63` と表示され、他の全エラー経路(`BinaryOperation::symbol()` = `^`)と演算子表記が食い違うバグを修正する。

## 背景

#42 のレビュー時に「`^` で入力しても `**` と表示される」点を既知の妥協として開示していた。バグハント継続の中で、これはエラーメッセージ層の表記が 2 系統に割れている問題だと再評価し、修正することにした。

## 課題

`binary_numeric.rs` の checked 演算は演算子記号を各アームでハードコードしており、Power だけ `"**"` を渡していた。一方、型エラー(`unsupported operation: ... ^ ...`)は `BinaryOperation::symbol()`(`^` を返す)でレンダリングされる。`ccc "2 ^ 63"` と入力したユーザーが、書いた覚えのない `**` をエラーで見ることになる。

## 目標

### 必須項目

- オーバーフローエラーの演算子表記が `BinaryOperation::symbol()` と一致する(single source of truth 化)
- エラー以外の評価結果は不変

### 範囲外

- AST に入力時の字面(`^` か `**` か)を保持する変更(desugar 方針の変更になるため)

## 採用手法

`evaluate_binary_integer` の冒頭で `operator.symbol()` を束縛し、全 checked アームと `evaluate_integer_power` に引き渡す。ハードコードされた記号文字列を排除したため、eval 層と type-check 層の表記が構造的に乖離できなくなった。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: `operator.symbol()` を全アームに配線(採用) | 表記の単一情報源化。将来の演算子追加でも乖離しない | Power の `**` 入力時も `^` と表示される |
| B: Power のみ `"^"` に書き換え | 差分最小 | 他アームのハードコードが残り、同種の乖離が再発しうる |
| C: AST が入力字面を保持 | 入力どおりの表示 | Expression 構造の変更が全層に波及。エラー表示のためだけには過大 |

### 採用理由

`symbol()` は「エラーメッセージ用の正準表記」としてドメイン層に既に存在する。表記の決定権をそこへ一元化するのが、ハードコードの再発を防ぐ最小の構造的修正である。`**` は `^` の同義語としてドキュメント化済み(#46)であり、`^` 表示は正準形として妥当。

## 変更箇所

- `ccc/infrastructure/src/evaluator/binary_numeric.rs`: 記号のハードコードを `operator.symbol()` に置換
- `ccc/infrastructure/src/evaluator/ast_evaluator_test/power_unary.rs`: 期待メッセージを `2 ^ 64` に更新

## 妥協と制限

- **`**` 入力時の表示**: `2 ** 64` と入力してもエラーは `2 ^ 64` と表示する。両者は文書化された同義語であり、正準形 `^` に正規化されるものとした

## 検証方法

- 全 380 テストパス、clippy / fmt クリーン
- 手動確認: `2 ^ 63` / `2 ** 63` とも `integer overflow: 2 ^ 63`、`2 ** 62` は従来どおり値を返す

## 確認事項

- ⚠️ `**` 入力時も `^` 表示に正規化する方針(選択肢 C を採らない)で問題ないか

## 参考文献

- 関連 PR: #42(オーバーフローエラー導入時に本件を妥協として開示)、#46(`**` を `^` の同義語として文書化)
