### PR TITLE
Name the unsupported element type in list-collector errors

### DIFF
--- a/ccc/infrastructure/src/evaluator/ast_evaluator_test/list.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator_test/list.rs
@@ -102,3 +102,25 @@ fn eval_prod_overflow_is_error() {
         CccError::eval("prod: integer overflow".to_string())
     );
 }
+
+#[test]
+fn eval_variance_of_durations_reports_unsupported_elements() {
+    // Arrange: elements are homogeneous, so the error must name the unsupported
+    // type instead of claiming a type mismatch
+    let expression = call(
+        "variance",
+        vec![list(vec![
+            crate::test_fixture::duration_literal(0, 1, 30),
+            crate::test_fixture::duration_literal(0, 0, 30),
+        ])],
+    );
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("variance: expected numeric list elements, got duration".to_string())
+    );
+}

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_helpers/collection.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_helpers/collection.rs
@@ -1,14 +1,18 @@
 use domain::error::CccError;
 use domain::value::Value;
 
+// Mixed-type lists are rejected by the type checker, so a non-numeric element
+// here means the whole (homogeneous) list has an unsupported type — say so
+// instead of the misleading "must be the same type".
 pub fn collect_numbers(name: &str, elements: &[Value]) -> Result<Vec<f64>, CccError> {
     elements
         .iter()
         .map(|e| match e {
             Value::Integer(n) => Ok(*n as f64),
             Value::Float(n) => Ok(*n),
-            _ => Err(CccError::eval(format!(
-                "{name}: list elements must be the same type"
+            other => Err(CccError::eval(format!(
+                "{name}: expected numeric list elements, got {}",
+                other.type_name()
             ))),
         })
         .collect()
@@ -19,8 +23,9 @@ pub fn collect_seconds(name: &str, elements: &[Value]) -> Result<Vec<i64>, CccEr
         .iter()
         .map(|e| match e {
             Value::DurationTime(s) => Ok(s.seconds()),
-            _ => Err(CccError::eval(format!(
-                "{name}: list elements must be the same type"
+            other => Err(CccError::eval(format!(
+                "{name}: expected duration list elements, got {}",
+                other.type_name()
             ))),
         })
         .collect()
@@ -31,8 +36,9 @@ pub fn collect_integers(name: &str, elements: &[Value]) -> Result<Vec<i64>, CccE
         .iter()
         .map(|e| match e {
             Value::Integer(n) => Ok(*n),
-            _ => Err(CccError::eval(format!(
-                "{name}: list elements must be the same type"
+            other => Err(CccError::eval(format!(
+                "{name}: expected integer list elements, got {}",
+                other.type_name()
             ))),
         })
         .collect()


### PR DESCRIPTION
## 概要

`variance([1:30:00, 0:30:00])` が「list elements must be the same type」と報告するバグを修正する。要素はすべて同型であり、実際の問題は「variance が duration を扱えない」こと。エラーが未対応の型名を明示するようにした。

## 背景

バグハント継続イテレーションで、#42 時点から記録していた既知課題「duration リストへの variance のエラーメッセージが誤解を招く」を精査した。根因は variance 固有ではなく、リスト collector ヘルパーが混在型向けの文言を流用していることだった。

## 課題

`collect_numbers` / `collect_seconds` / `collect_integers` は非対応要素に遭遇すると一律「{name}: list elements must be the same type」を返す。しかし混在型リストは型チェッカーが評価前に拒否する(`list elements must be the same type, expected ... at index ...`)ため、eval 時にこの分岐へ到達するのは「同型だが未対応の型のリスト」のみ。つまりこのメッセージは到達時点で常に嘘になる。`mean([[1],[2]])` でも同じ誤誘導が起きる。

## 目標

### 必須項目

- 同型・未対応型のリストに対するエラーが未対応の型名を明示する(例: `variance: expected numeric list elements, got duration`)
- 正常系(数値リストの variance、duration リストの mean 等)の結果は不変

### 範囲外

- variance に duration サポートを追加すること(単位が秒²になり意味が不明瞭なため、対応しない判断は維持)
- 型チェッカー側のメッセージ変更

## 採用手法

3 つの collector の非対応分岐を `{name}: expected <kind> list elements, got {type_name}` に置き換える。`fold_numbers` が既に採っている正確な文言スタイル(何が必要で何が来たか)に揃えた。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: collector の文言を実態に合わせる(採用) | 3 関数(variance/mean/median ほか)を一括で正す。got の型名で診断が即完了する | 無し |
| B: variance 側でだけ duration を事前ガード | 差分最小 | mean/median のリスト・オブ・リスト等、同根の誤誘導が残る |

### 採用理由

誤誘導の根は collector にあり、呼び出し側での個別ガードは同じバグの再発を許す。型チェッカーとの責務分担(混在検出は checker、型サポート判定は eval)をコメントで明文化した。

## 変更箇所

- `ccc/infrastructure/src/evaluator/builtin/builtin_helpers/collection.rs`: 3 collector のエラーを「expected <kind> list elements, got <type>」に変更
- `ccc/infrastructure/src/evaluator/ast_evaluator_test/list.rs`: duration リストへの variance の回帰テストを追加

## 妥協と制限

- **`collect_seconds` / `collect_integers` の分岐は現状実質到達不能**(型チェッカーが先に混在を排除するため)だが、防御的コードとして残し文言のみ正した

## 検証方法

- 追加テスト 1 件を含む全 381 テストパス、clippy / fmt クリーン(complexity は 15.17 → 14.26 に改善)
- 手動確認: `variance([1:30, 0:30])` → `expected numeric list elements, got duration`、`mean([[1],[2]])` → `got list`、`variance([1,2,3])` → `0.666...` 不変

## 確認事項

- ⚠️ variance の duration 非対応(仕様として維持)でよいか

## 参考文献

- 関連 PR: #42(本課題を既知事項として記録)、#43(型チェッカーの混在型検出仕様)
