### PR TITLE
Keep float form for timestamps outside the i64 range

### DIFF
--- a/ccc/domain/src/value_display.rs
+++ b/ccc/domain/src/value_display.rs
@@ -59,8 +59,12 @@ fn format_datetime(
 }
 
 fn format_timestamp(f: &mut std::fmt::Formatter<'_>, ts: f64) -> std::fmt::Result {
-    if ts == ts.trunc() {
-        // Display as integer when there's no fractional part
+    // `ts as i64` saturates outside the i64 range (and for infinities), which
+    // would render e.g. 1e30 as 9223372036854775807. Take the integer form only
+    // when the value actually fits; `<` also excludes 2^63 itself because
+    // i64::MAX as f64 rounds up to 2^63 exactly.
+    let fits_in_i64 = ts >= i64::MIN as f64 && ts < i64::MAX as f64;
+    if ts == ts.trunc() && fits_in_i64 {
         write!(f, "{}", ts as i64)
     } else {
         write!(f, "{ts}")

--- a/ccc/domain/src/value_test.rs
+++ b/ccc/domain/src/value_test.rs
@@ -379,4 +379,29 @@ mod tests {
         // Assert
         assert_eq!(result, "0");
     }
+
+    #[test]
+    fn display_timestamp_beyond_i64_keeps_float_value() {
+        // Arrange: 1e30 has no fractional part but exceeds i64, so the
+        // integer path would saturate it to 9223372036854775807
+        let value = Value::Timestamp(1e30);
+
+        // Act
+        let result = format!("{value}");
+
+        // Assert
+        assert_eq!(result, "1000000000000000000000000000000");
+    }
+
+    #[test]
+    fn display_timestamp_infinity() {
+        // Arrange
+        let value = Value::Timestamp(f64::INFINITY);
+
+        // Act
+        let result = format!("{value}");
+
+        // Assert
+        assert_eq!(result, "inf");
+    }
 }


### PR DESCRIPTION
## 概要

`Timestamp(10.0 ** 30)` が `9223372036854775807`(i64::MAX)と表示されるバグを修正する。i64 に収まらない timestamp は float 表示のまま値を忠実に表示する。

## 背景

バグハント継続イテレーションで timestamp の表示経路を精査した。#44/#47 で潰した「`as i64` の飽和」と同じパターンが表示層(`value_display.rs`)にも残っていた。

## 課題

`format_timestamp` は「小数部がなければ整数として表示」する際に `ts as i64` を使っていた。この cast は範囲外で飽和するため、`1e30` のような巨大値が `9223372036854775807` という捏造された値で表示される。さらに `inf` は `inf.trunc() == inf` が成り立つため同じ整数経路に入り、無限大まで i64::MAX として表示されていた。

## 目標

### 必須項目

- i64 範囲外の timestamp(巨大値・±inf)が float 表示で正しい値を示す
- 範囲内の表示(整数形 `100`、小数形 `1.5`)は不変

### 範囲外

- `Timestamp()` コンストラクタが巨大値・非有限値を受理すること自体の是非(#47 の確認事項として別途検討)
- 巨大 float の表示形式(Rust の Display 準拠、指数表記なし)

## 採用手法

整数経路の条件に「i64 に実際に収まること」を追加する。上限は `< i64::MAX as f64` を使う: `i64::MAX as f64` は 2^63 ちょうどに丸められるため、`<` 比較で 2^63 自体も除外される(#44 の `float_to_i64` と同じ境界判定)。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: 整数経路を i64 範囲内に限定(採用) | 最小差分で全域の表示が忠実になる | 巨大値は Rust の float 表示(31 桁の 10 進)になる |
| B: 表示層で `{:.0}` 等の書式指定 | cast 不要 | 小数形との使い分けロジックが複雑化し、既存表示との互換確認が広がる |

### 採用理由

このヘルパーの意図は「整数値の timestamp から `.0` を省く」ことだけであり、範囲ガードの追加がその意図を保ったままバグだけを除去する最小修正。境界判定は既存の `float_to_i64`(#44)と同一で、コードベース内の一貫性も保たれる。

## 変更箇所

- `ccc/domain/src/value_display.rs`: `format_timestamp` の整数経路に i64 範囲ガードを追加
- `ccc/domain/src/value_test.rs`: `1e30` と `inf` の表示回帰テストを 2 件追加

## 妥協と制限

無し(表示のみの変更で、評価結果・エラー挙動に影響しない)。

## 検証方法

- 追加テスト 2 件を含む全 383 テストパス、clippy / fmt クリーン
- 手動確認: `Timestamp(10.0 ** 30)` → `1000000000000000000000000000000`、`Timestamp(10.0 ** 400)` → `inf`、`Timestamp(100)` → `100`、`Timestamp(1.5)` → `1.5`

## 確認事項

- ⚠️ 巨大 timestamp の表示は Rust の float Display(指数表記なしの全桁)に従う。指数表記を望む場合は別途表示仕様の議論が必要

## 参考文献

- 関連 PR: #44(float→int キャストの同一境界判定)、#47(timestamp→datetime キャストの NaN 拒否)
