### PR TITLE
Make ci.yml and release.yml comply with workflow lint policies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,54 +22,82 @@ on:
       - "flake.lock"
       - ".github/workflows/ci.yml"
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   format:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: rustfmt
       - run: cargo fmt --all --check
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo clippy --workspace -- -D warnings
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo build --workspace
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test --workspace
 
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo install cargo-tarpaulin
       - run: cargo tarpaulin --workspace --out xml --skip-clean
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report
           path: cobertura.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,25 +3,35 @@ name: Release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   prepare:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Extract version from Cargo.toml
         id: version
         run: |
           version=$(grep -m1 '^version' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
           echo "version=${version}" >>"$GITHUB_OUTPUT"
       - name: Check tag does not exist
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "::error::Tag v${{ steps.version.outputs.version }} already exists"
+          if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag v${VERSION} already exists"
             exit 1
           fi
 
@@ -37,20 +47,30 @@ jobs:
             runner: macos-14
             artifact: ccc-aarch64-apple-darwin
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        env:
+          TARGET: ${{ matrix.target }}
+        run: cargo build --release --target "${TARGET}"
       - name: Package
+        env:
+          TARGET: ${{ matrix.target }}
+          ARTIFACT: ${{ matrix.artifact }}
         run: |
           mkdir -p dist
-          cp target/${{ matrix.target }}/release/ccc dist/ccc
-          tar -czf ${{ matrix.artifact }}.tar.gz -C dist ccc
-      - uses: actions/upload-artifact@v4
+          cp "target/${TARGET}/release/ccc" dist/ccc
+          tar -czf "${ARTIFACT}.tar.gz" -C dist ccc
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}.tar.gz
@@ -58,22 +78,32 @@ jobs:
   release:
     needs: [prepare, build]
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
+      # Tag via the API instead of `git push` so the checkout does not need
+      # persisted credentials (ghalint policy 013).
       - name: Create tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          git tag "v${{ needs.prepare.outputs.version }}"
-          git push origin "v${{ needs.prepare.outputs.version }}"
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/v${VERSION}" \
+            -f sha="${GITHUB_SHA}"
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          gh release create "v${{ needs.prepare.outputs.version }}" \
-            --title "v${{ needs.prepare.outputs.version }}" \
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
             --generate-notes \
             artifacts/**/*.tar.gz


### PR DESCRIPTION
## 概要

shunsock/github_central から同期された managed lint ワークフロー(actionlint / ghalint / zizmor)のポリシーに、既存の ci.yml / release.yml を準拠させる。現状は全 PR がコード内容と無関係に CI 失敗する状態になっている。

## 背景

main に「ci: sync managed workflows from shunsock/github_central」(99339b4)が入り、全 PR で GitHub Actions のセキュリティリンタが走るようになった。バグ修正 PR #50 の CI でこのゲートが発火し、ghalint(exit 1)と zizmor(exit 14)が既存ワークフローの違反を検出した。

## 課題

ci.yml / release.yml が新ポリシーに違反している:

- 全 action 参照がタグ/ブランチ参照(SHA pin なし)— ghalint policy 008 / zizmor unpinned(error)
- 全 job に `permissions` 未宣言 — ghalint policy 001 / zizmor overly-broad(warning)
- 全 job に `timeout-minutes` 未設定 — ghalint policy 012
- checkout が `persist-credentials: false` 未設定 — ghalint policy 013 / zizmor(warning)
- release.yml の run ブロックにテンプレート展開直書き — zizmor code-injection(notice)

これらが解消されるまで、すべての PR が本来の変更と無関係に赤になる。

## 目標

### 必須項目

- actionlint / ghalint / zizmor がローカルで exit 0
- CI・リリースの実行内容(ビルド・テスト・成果物)は同一

### 範囲外

- managed 側ワークフロー(lint__*.yaml)の変更(github_central 管理のため触らない)
- action のメジャーバージョン更新(v4→v7 等)— pin のみ行い、挙動変更を持ち込まない

## 採用手法

managed ワークフロー(lint__github_actions.yaml)が示す書式を規範として全 job を整えた。

- SHA pin: 現行と同系列の最新タグの commit SHA + バージョンコメント(checkout v4.2.2 / rust-cache v2.9.1 / upload-artifact v4.6.2 / download-artifact v4.3.0 / dtolnay stable branch HEAD)
- permissions: workflow レベル + job レベルで `contents: read`(release job のみ `contents: write`)
- timeout-minutes: 実測所要(15-30 秒)に余裕を持たせ 5-30 分
- persist-credentials: 全 checkout で false。release のタグ作成だけが `git push` で認証情報に依存していたため、`gh api repos/…/git/refs`(job token)での作成に置き換えた
- テンプレート展開: run ブロック内の `${{ }}` を env 経由に変更(zizmor code-injection 対策)

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: ワークフローをポリシー準拠に修正(採用) | 全 PR のゲートが恒久的に解消。サプライチェーン安全性も向上 | SHA pin の更新運用が必要(Renovate 等は将来課題) |
| B: `.ghalint.yml` / zizmor config で除外 | 差分最小 | ポリシーを骨抜きにする。managed 同期の意図(強制)に反する |
| C: バグ修正 PR (#50) に同梱 | PR 数削減 | 無関係な変更の混入(1 Issue 1 PR 違反)。以後の全 PR も赤のまま |

### 採用理由

リンタ導入の意図は「ポリシーの強制」であり、除外設定は本末転倒。独立 PR での準拠が、進行中の全 PR(#50 含む)を最短でクリーンにする。

## 変更箇所

- `.github/workflows/ci.yml`: 全 5 job に SHA pin・permissions・timeout-minutes・persist-credentials: false を追加
- `.github/workflows/release.yml`: 同上に加え、タグ作成を `git push` から `gh api` へ置換、run ブロックの展開を env 経由に変更

## 妥協と制限

- **dtolnay/rust-toolchain の pin**: `stable` はムービングブランチのため、pin により toolchain 更新が自動追従しなくなる。SHA 更新の運用(Renovate 導入等)は別課題
- **yamllint のコメント前スペース warning**: prettier と managed ファイルの流儀(1 スペース)に合わせ、warning(exit 0)は許容

## 検証方法

- ローカルで `actionlint`、`ghalint run`、`zizmor --offline` すべて exit 0(22 findings → 0)
- prettier / yamllint(exit 0)、埋め込み run ブロックの認知的複雑度 ≤ 2.08
- ci.yml のジョブ定義(トリガー・実行コマンド)は無変更であることを diff で確認

## 確認事項

- ⚠️ リリースのタグ作成が `git push` から `gh api` になる(タグは GITHUB_SHA を指す。workflow_dispatch の実行 ref と一致)
- ⚠️ dtolnay/rust-toolchain を stable ブランチの現時点 HEAD に固定した。toolchain 更新時は SHA の手動更新が必要

## 参考文献

- [ghalint policies](https://github.com/suzuki-shunsuke/ghalint/tree/main/docs/policies) (001, 008, 012, 013)
- 関連 PR: #50(本ゲートで CI 失敗中のバグ修正 PR)
- 関連 commit: 99339b4(managed workflows 同期)
