### PR TITLE
Reject non-finite Timestamp constructor arguments

### DIFF
--- a/ccc/infrastructure/src/evaluator/ast_evaluator_test/timestamp.rs
+++ b/ccc/infrastructure/src/evaluator/ast_evaluator_test/timestamp.rs
@@ -44,6 +44,40 @@ fn eval_timestamp_constructor_wrong_arg_count() {
     assert!(result.is_err());
 }
 
+#[test]
+fn eval_timestamp_constructor_rejects_nan() {
+    // Arrange
+    use crate::test_fixture::float;
+    use domain::error::CccError;
+    let expression = call("Timestamp", vec![float(f64::NAN)]);
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("Timestamp: expected finite number, got NaN".to_string())
+    );
+}
+
+#[test]
+fn eval_timestamp_constructor_rejects_infinity() {
+    // Arrange
+    use crate::test_fixture::float;
+    use domain::error::CccError;
+    let expression = call("Timestamp", vec![float(f64::INFINITY)]);
+
+    // Act
+    let result = eval(expression);
+
+    // Assert
+    assert_eq!(
+        result.unwrap_err(),
+        CccError::eval("Timestamp: expected finite number, got inf".to_string())
+    );
+}
+
 // --- Timestamp arithmetic ---
 
 #[test]
@@ -144,7 +178,9 @@ fn eval_round_trip_datetime_timestamp() {
 
 #[test]
 fn cast_nan_timestamp_to_datetime_is_error() {
-    // Arrange: Timestamp(NaN) as datetime — NaN must not become epoch 0
+    // Arrange: the constructor now rejects NaN first, so the pipeline still
+    // cannot turn "not a number" into epoch 0 (the cast guard remains as
+    // defense in depth)
     use crate::test_fixture::{cast, float};
     use domain::ast::CastTargetType;
     use domain::error::CccError;
@@ -159,7 +195,7 @@ fn cast_nan_timestamp_to_datetime_is_error() {
     // Assert
     assert_eq!(
         result.unwrap_err(),
-        CccError::eval("cannot cast NaN timestamp to datetime".to_string())
+        CccError::eval("Timestamp: expected finite number, got NaN".to_string())
     );
 }
 
@@ -180,6 +216,6 @@ fn cast_infinite_timestamp_to_datetime_is_error() {
     // Assert
     assert_eq!(
         result.unwrap_err(),
-        CccError::eval("timestamp out of datetime range".to_string())
+        CccError::eval("Timestamp: expected finite number, got inf".to_string())
     );
 }

--- a/ccc/infrastructure/src/evaluator/builtin/builtin_constructor.rs
+++ b/ccc/infrastructure/src/evaluator/builtin/builtin_constructor.rs
@@ -71,5 +71,12 @@ pub fn datetime_constructor(arguments: &[Value]) -> Result<Value, CccError> {
 pub fn timestamp_constructor(arguments: &[Value]) -> Result<Value, CccError> {
     let arg = expect_single_arg("Timestamp", arguments)?;
     let n = to_f64(arg)?;
+    // NaN/inf are not points in time; rejecting them here keeps every
+    // downstream consumer (casts, arithmetic, display) free of non-finite input.
+    if !n.is_finite() {
+        return Err(CccError::eval(format!(
+            "Timestamp: expected finite number, got {n}"
+        )));
+    }
     Ok(Value::Timestamp(n))
 }


### PR DESCRIPTION
## 概要

`Timestamp()` コンストラクタが NaN・無限大を受理するのをやめ、非有限な timestamp を型として存在不可能にする。#47 で保留していた設計判断の決着。

## 背景

`Timestamp(sqrt(0-4))` は NaN の timestamp を生成でき、それがパイプライン全体を流れるため、#47(datetime キャスト)・#50(表示層)と、下流の各所で個別のガードを追加してきた。もぐら叩きの根を断つには発生源での拒否が必要だった。

## 課題

「数でないもの」「無限」は時刻ではない。にもかかわらず構築できてしまうため、Timestamp を受け取るすべてのコード(キャスト・演算・表示・将来の機能)が非有限値を考慮する義務を負っていた。

## 目標

### 必須項目

- `Timestamp(NaN)` / `Timestamp(±inf)` が `Timestamp: expected finite number, got <value>` の eval エラーになる
- 有限値のコンストラクタ・timestamp 演算・`current_timestamp()` は不変

### 範囲外

- 既存の下流ガード(#47 キャスト・#50 表示)の削除 — defense in depth として残す
- 巨大有限値(1e30 等)の拒否 — 意味論上は有効な f64 時刻として維持

## 採用手法

コンストラクタに `is_finite()` ガードを追加する(Make Illegal States Unrepresentable)。`Value::Timestamp` を生成する経路はコンストラクタ・`current_timestamp()`(常に有限)・`datetime as timestamp`(有限 epoch 由来)・timestamp±duration(有限+有限で f64 範囲内)のみであり、この 1 箇所で非有限 timestamp が全経路から消える。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: コンストラクタで拒否(採用) | 発生源 1 箇所で全下流が単純化。#42 以降の「境界で拒否」方針と一貫 | NaN を含む式の評価が構築時点で止まる |
| B: 下流ガードの積み増し継続 | 局所変更のみ | 新しい消費側を書くたびに同じガードが必要。#47/#50 で 2 度発生済み |

### 採用理由

同じクラスのバグが 2 回(#47, #50)発生しており、下流対応の限界は実証済み。値オブジェクトの構築時検証は EpochSeconds / UtcOffset が既に採る方針で、Timestamp だけが例外だった。

## 変更箇所

- `ccc/infrastructure/src/evaluator/builtin/builtin_constructor.rs`: `timestamp_constructor` に非有限値ガードを追加
- `ccc/infrastructure/src/evaluator/ast_evaluator_test/timestamp.rs`: コンストラクタ拒否のテスト 2 件を追加。#47 の cast テスト 2 件は構築段階でエラーになるため期待値を更新(cast ガード自体は defense in depth として存置)

## 妥協と制限

- **#47 の cast ガードが通常経路では到達不能になる**: 防御的コードとして残すが、eval 経由のテストでは直接検証できなくなった(コンストラクタが先に落ちるため)

## 検証方法

- 全 383 テストパス(追加 2 件・更新 2 件含む)、clippy / fmt クリーン
- 手動確認: `Timestamp(sqrt(0-4))` / `Timestamp(10.0 ** 400)` がエラー、`Timestamp(1.5)` → `1.5`、`Timestamp(100) + 0:30` → `130` は不変

## 確認事項

- ⚠️ 到達不能になった #47 の cast ガードを削除せず残す判断(防御優先)でよいか

## 参考文献

- 関連 PR: #47(cast ガード・本設計判断の保留元)、#50(表示層ガード)
