### PR TITLE
ci: ci.yml の paths filter をジョブ内部化して全 PR で check を報告する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,24 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
-    paths:
-      - "**.rs"
-      - "**.pest"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "flake.nix"
-      - "flake.lock"
-      - ".github/workflows/ci.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "**.rs"
-      - "**.pest"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "flake.nix"
-      - "flake.lock"
-      - ".github/workflows/ci.yml"
 
 permissions:
   contents: read
@@ -29,7 +13,34 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # rust に関わる変更があるかを判定する。無関係な PR (github-actions 更新等) では
+  # 後続ジョブを skip するが、skip された required check は "passing" 扱いになるため
+  # auto-merge が詰まらない。workflow-level の paths filter を使うと workflow 自体が
+  # 発火せず required check が「待ち」で詰まるため、判定をジョブ内部へ移している。
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            rust:
+              - '**.rs'
+              - '**.pest'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'flake.nix'
+              - 'flake.lock'
+              - '.github/workflows/ci.yml'
+
   format:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -44,6 +55,8 @@ jobs:
       - run: cargo fmt --all --check
 
   lint:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -59,6 +72,8 @@ jobs:
       - run: cargo clippy --workspace -- -D warnings
 
   build:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -72,6 +87,8 @@ jobs:
       - run: cargo build --workspace
 
   test:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -85,6 +102,8 @@ jobs:
       - run: cargo test --workspace
 
   coverage:
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## 概要

`ci.yml` の workflow-level paths filter をジョブ内部（`changes` 検出ジョブ + `if`）へ移し、全 PR で `format`/`lint`/`build`/`test` の check を必ず報告するようにする。dependabot auto-merge の required status check 化に向けた前提整備。

## 背景

ccc を rust-cli auto-merge グループ（shunsock/github_central）へ載せる計画で、`format`/`lint`/`build`/`test` を ruleset の required status check にしたい。ところが現状の `ci.yml` は workflow-level の `paths:` を持つため、rust に無関係な PR（例: github-actions の dependabot 更新）では **workflow 自体が発火せず** これらの status が報告されない。

## 課題

- required にすると、非 rust PR で required check が「待ち」のままマージが永久に詰まる。
- required から外すと cargo 更新がビルド未検証で auto-merge され危険。

## 採用手法

workflow-level の `paths` を撤去し、`changes` ジョブ（`dorny/paths-filter`, SHA 固定）で rust 変更を判定。`format`/`lint`/`build`/`test`/`coverage` を `needs: changes` + `if: needs.changes.outputs.rust == 'true'` にする。rust 無関係な PR では各ジョブが skip され、**skip された required check は passing 扱い**になるため詰まらない。cargo 更新では従来どおり全ジョブが走り実検証される。

## 変更箇所

- `.github/workflows/ci.yml`: `on.*.paths` を撤去。`changes` 検出ジョブを追加し、既存 5 ジョブを条件付き実行に

## 妥協と制限

- 非 rust PR でも `changes` ジョブ（paths-filter のみ）は起動する。実質コストは軽微。

## 検証方法

- `actionlint` / `ghalint` / `zizmor` pass
- 本 PR は `ci.yml`（rust filter 対象）を変更するため全ジョブが走り、書き換え後も CI が通ることを確認できる
- skip 経路（非 rust PR で skip=passing）は今後の github-actions dependabot PR で確認

## 確認事項

- ⚠️ この後 github_central 側で ccc を PR 必須化し、required_status_checks に format/lint/build/test + lint5 を設定する（coverage は除外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)